### PR TITLE
fix ability to define header block

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -29,7 +29,7 @@ module GraphQL
       # block - Optional block to configure class
       def initialize(uri, &block)
         @uri = URI.parse(uri)
-        class_eval(&block) if block_given?
+        instance_eval(&block) if block_given?
       end
 
       # Public: Parsed endpoint URI


### PR DESCRIPTION
When trying to define a custom header as a block like below:
```
module GitHubAPI
  HTTP = GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
    def headers(context)
      {
          "Authorization" => "Bearer #{ENV['GITHUB_AUTH_TOKEN']}"
      }
    end
  end
  Schema = GraphQL::Client.load_schema(HTTP)
  Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
end
```

 I get this error:

/Users/davidx/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.1.0/lib/graphql/client/http.rb:32:in `initialize': undefined method `class_eval' for #<GraphQL::Client::HTTP:0x007fa871b0ee58> (NoMethodError)
	from tt.rb:7:in `new'
	from tt.rb:7:in `<module:GitHubAPI>'
	from tt.rb:4:in `<main>'

Hence, I think it should be an instance eval. :) Thanks!