### PR TITLE
Don't serialize variables to JSON twice

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -66,7 +66,7 @@ module GraphQL
 
         body = {}
         body["query"] = document.to_query_string
-        body["variables"] = JSON.generate(variables) if variables.any?
+        body["variables"] = variables if variables.any?
         body["operationName"] = operation_name if operation_name
         request.body = JSON.generate(body)
 


### PR DESCRIPTION
## The issue 

When using the `graphql-client`, e.g. when doing a call like: 

```ruby
SWAPI::Client.query(HeroQuery, variables: { name: "Kylo Ren" })
```

It generates a request with `variables` being a serialized JSON object 

````JSON
  { 
    "query": "...", 
    "variables":"{\"name\":\"Kylo Ren\"}"  
}
```

When hitting our graphql controller on Ruby, this means that variables doesn't get interpreted as a hash and requires additional parsing. For example, the code we have to deal with this: 

```ruby
class GraphController < ApiController
  def execute
    render json: Graph::Schema.execute(params[:query], variables: variables || {})
  end

  private

  def variables
    if params[:variables].is_a?(String)
      JSON.parse(params[:variables]) # For handling requests from graphql-client
    else
      params[:variables] # For Relay this works
    end
  end
end
```

## Investigation
I did some reading on the GQL spec, but couldn't find anything about the serialization of variables. However, we're also using Relay with the same endpoint and in the Relay payloads,`variables` is part of the JSON object itself rather than being a serialized string. For example: 

```json
{ "query": "...", "variables":{"id_0":"VXNlci0tLTI="} }
```

## The PR 
Looked in the code and realized that variables is serialized to JSON twice. Removed that as a potential fix. The tests passed on the change because it seems to be directly executing a call on the schema, hence skipping the serialization.

Happy to work on testing this and it will be nice to get some direction on how to do a test where an actual request is made. 