### PR TITLE
Expose the ability to customize the underlying Net::HTTP object

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -55,9 +55,6 @@ module GraphQL
       #
       # Returns { "data" => ... , "errors" => ... } Hash.
       def execute(document:, operation_name: nil, variables: {}, context: {})
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme == "https"
-
         request = Net::HTTP::Post.new(uri.request_uri)
 
         request["Accept"] = "application/json"
@@ -70,12 +67,21 @@ module GraphQL
         body["operationName"] = operation_name if operation_name
         request.body = JSON.generate(body)
 
-        response = http.request(request)
+        response = connection.request(request)
         case response
         when Net::HTTPOK, Net::HTTPBadRequest
           JSON.parse(response.body)
         else
           { "errors" => [{ "message" => "#{response.code} #{response.message}" }] }
+        end
+      end
+
+      # Public: Extension point for subclasses to customize the Net:HTTP client
+      #
+      # Returns a Net::HTTP object
+      def connection
+        @connection ||= Net::HTTP.new(uri.host, uri.port).tap do |client|
+          client.use_ssl = uri.scheme == "https"
         end
       end
     end

--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -67,8 +67,6 @@ module GraphQL
         body["operationName"] = operation_name if operation_name
         request.body = JSON.generate(body)
 
-        connection.start unless connection.started?
-
         response = connection.request(request)
         case response
         when Net::HTTPOK, Net::HTTPBadRequest
@@ -82,7 +80,7 @@ module GraphQL
       #
       # Returns a Net::HTTP object
       def connection
-        @connection ||= Net::HTTP.new(uri.host, uri.port).tap do |client|
+        Net::HTTP.new(uri.host, uri.port).tap do |client|
           client.use_ssl = uri.scheme == "https"
         end
       end

--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -67,6 +67,8 @@ module GraphQL
         body["operationName"] = operation_name if operation_name
         request.body = JSON.generate(body)
 
+        connection.start unless connection.started?
+
         response = connection.request(request)
         case response
         when Net::HTTPOK, Net::HTTPBadRequest


### PR DESCRIPTION
## What's up

Hi again, a PR on exposing the underlying `Net::HTTP` object so it can be customized. 

## Use case 
We are using `graphql-client` to do server to server GQL communications. We have a microservice that uses Google's `libphonenumber` to expose phone number parsing capabilities and that has a GQL API front. Since there's no IO, typical response times are around 4-15 ms. 

We hit this microservice from our main Rails app and require a strict timeout and fallback to a local parsing service (slightly inferior but mostly works). 

This led to the desire to be able to customize the `Net::HTTP` object, such as setting `open_timeout` and `keep_alive_timeout`

## Changes 
After looking through the code, the instantiation of the http client is done under the `execute` method. Since there is only one instance of `GraphQL:Client:HTTP` in the app typically, the http client can be reused over. 

I moved the `Net::HTTP` instantiation to a memoized instance method `connection`, so it's accessible for customization and it's reused.

## Keeping the connection active 

Since this is a Ruby client, I imagine it can be a common use case to have the connection stay alive. By default, the timeout is 2 seconds if we started the connection manually. 

Added a small addition to start the connection on first request and did some benchmarks against SWAPI. 

### Code
```ruby
HeroQuery = SWAPI::Client.parse <<~GQL
  query($id: ID!) {
    person(personID: $id) {
      name
    }
  }
GQL

puts Benchmark.measure do 
  30.times do
    SWAPI::Client.query(HeroQuery, variables: { id: 1 }) 
  end 
end
```

### Current master
> 0.030000   0.020000   0.050000 ( 10.651987)


### With persistent connections
> 0.020000   0.010000   0.030000 (  9.303729)

This is a trivial example and we're hitting the API in serial, so the benchmarks can be misleading. SWAPI probably has no IO and a very short response time, making the benchmarks more significant. 

In our own `libphonenumber` app, which has a low response (10-20 ms), keeping the connection alive also helped to get much more throughput from a Rails console. 

<img width="757" alt="screen_shot_2016-10-07_at_12_42_08_am" src="https://cloud.githubusercontent.com/assets/1251946/19179038/189b77b6-8c27-11e6-8e2d-eb30dee014b1.png">

Since there is already a default timeout of closing the connection, I thought it might be good to just keep it alive within that period, benefiting requests that are issued in close proximity. 
