### PR TITLE
Reduce allocations due to collocation enforcement

### DIFF
--- a/lib/graphql/client/collocated_enforcement.rb
+++ b/lib/graphql/client/collocated_enforcement.rb
@@ -29,10 +29,10 @@ module GraphQL
             define_method(method) do |*args, &block|
               return super(*args, &block) if Thread.current[:query_result_caller_location_ignore]
 
-              locations = caller_locations(1)
+              locations = caller_locations(1, 1)
               if locations.first.path != path
                 error = NonCollocatedCallerError.new("#{method} was called outside of '#{path}' https://git.io/v1syX")
-                error.set_backtrace(locations.map(&:to_s))
+                error.set_backtrace(caller(1))
                 raise error
               end
 

--- a/test/test_collocated_enforcement.rb
+++ b/test/test_collocated_enforcement.rb
@@ -56,4 +56,16 @@ class TestCollocatedEnforcement < MiniTest::Test
       format_person_info_via_send(person)
     end
   end
+
+  def test_exception_backtrace_excludes_enforce_collocated_callers
+    person = Person.new
+    begin
+      format_person_info(person)
+    rescue GraphQL::Client::NonCollocatedCallerError => e
+      exception = e
+    end
+
+    assert_includes exception.backtrace[0], "in `format_person_info'"
+    assert_includes exception.backtrace[1], "in `test_exception_backtrace_excludes_enforce_collocated_callers'"
+  end
 end


### PR DESCRIPTION
We now only allocate a single `Thread::Backtrace::Location` object (rather than one per stack frame) when callers are collocated. When callers are not collocated, we then allocate a full `Kernel#caller` array to fill in the exception's backtrace. This avoids many `Thread::Backtrace::Location` allocations in the happy path.

/cc @josh