### PR TITLE
Add support for http basic_auth

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -58,6 +58,8 @@ module GraphQL
       def execute(document:, operation_name: nil, variables: {}, context: {})
         request = Net::HTTP::Post.new(uri.request_uri)
 
+        request.basic_auth(uri.user, uri.password) if uri.user || uri.password
+
         request["Accept"] = "application/json"
         request["Content-Type"] = "application/json"
         headers(context).each { |name, value| request[name] = value }


### PR DESCRIPTION
This is a very crude PR, but I thought I'd better open it than to simply walk away (I was just doing a GraphQL test)

Didn't write a test for it, not really sure why that class is explicitly skipped:
https://github.com/github/graphql-client/blob/master/test/test_http.rb#L14

Down the road, maybe the `Net::HTTP::Post` class should get exposed in some way so there is no need for the indirection(allow interaction with the request object itself). This time it was basic_auth, next time it might be custom headers.

Thoughts?