### PR TITLE
Decorators

### DIFF
--- a/lib/graphql/client/decorator.rb
+++ b/lib/graphql/client/decorator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Client
+    module Decorator
+      def self.extended(base)
+        base.class_eval do
+          @_graphql_client_decorator_module = Module.new
+          prepend @_graphql_client_decorator_module
+        end
+      end
+
+      def decorate_fragment(sym, definitions)
+        @_graphql_client_decorator_module.send(:define_method, sym) do |*args, &block|
+          args = args.zip(definitions).map { |value, type| type ? type.new(value) : value }
+          super(*args, &block)
+        end
+      end
+    end
+  end
+end

--- a/test/test_decorator.rb
+++ b/test/test_decorator.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "graphql"
+require "graphql/client"
+require "graphql/client/decorator"
+require "minitest/autorun"
+require "ostruct"
+
+class TestDecorator < MiniTest::Test
+  PersonType = GraphQL::ObjectType.define do
+    name "Person"
+    field :login, types.String
+    field :firstName, types.String
+    field :lastName, types.String
+  end
+
+  QueryType = GraphQL::ObjectType.define do
+    name "Query"
+    field :me, !PersonType do
+      resolve ->(_query, _args, _ctx) {
+        OpenStruct.new(
+          login: "josh",
+          firstName: "Joshua",
+          lastName: "Peek"
+        )
+      }
+    end
+  end
+
+  Schema = GraphQL::Schema.define(query: QueryType)
+
+  Client = GraphQL::Client.new(schema: Schema, execute: Schema, enforce_collocated_callers: true)
+
+  extend GraphQL::Client::Decorator
+
+
+  Person = Client.parse(<<-'GRAPHQL')
+    fragment on Person {
+      login
+      firstName
+      lastName
+    }
+  GRAPHQL
+
+  def format_person_name(person)
+    "@#{person.login} (#{person.first_name} #{person.last_name})"
+  end
+  decorate_fragment :format_person_name, [Person]
+
+
+  Query = Client.parse(<<-'GRAPHQL')
+    {
+      me {
+        ...TestDecorator::Person
+      }
+    }
+  GRAPHQL
+
+  def test_decorated_format_person_name
+    response = Client.query(Query)
+    assert_equal "@josh (Joshua Peek)", format_person_name(response.data.me)
+  end
+end


### PR DESCRIPTION
Inspired by @aroben taking a stab at a decorator DSL internally to @github.

Design requirements:

* Works in any Ruby class/module
* Works with methods that accept multiple arguments
* Works with methods that accept keyword arguments
* Allows for multiple fragments per method
* Parsed query/fragment needs a constant name (either implicitly or explicitly set)

``` ruby
Person = Client.parse(<<-'GRAPHQL')
  fragment on Person {
    login
    firstName
    lastName
  }
GRAPHQL

def format_person_name(person)
  "@#{person.login} (#{person.first_name} #{person.last_name})"
end
decorate_fragment :format_person_name, [Person]
```

A quick spike, but I'm realizing why I didn't bother pursuing this anymore. So far its still **more** typing that just re-wrapping the argument in the first line of the method, `person = Person.new(person)`.

##

CC: @aroben @bswinnerton 