### PR TITLE
Appropriately cast custom scalars on interfaces

### DIFF
--- a/lib/graphql/client/query_result.rb
+++ b/lib/graphql/client/query_result.rb
@@ -82,7 +82,7 @@ module GraphQL
 
           fields.each do |field, klass|
             if @type.is_a?(GraphQL::ObjectType)
-              field_node = @type.fields[field.to_s]
+              field_node = @type.get_field(field.to_s)
               if field_node && field_node.type.unwrap.is_a?(GraphQL::ScalarType)
                 klass = Scalar.new(field_node.type.unwrap)
               end

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -17,8 +17,14 @@ class TestQueryResult < MiniTest::Test
     end
   end
 
+  HumanLike = GraphQL::InterfaceType.define do
+    name "HumanLike"
+    field :updatedAt, !DateTime
+  end
+
   PersonType = GraphQL::ObjectType.define do
     name "Person"
+    interfaces [HumanLike]
     field :login, types.String
     field :name, types.String
     field :firstName, types.String
@@ -44,6 +50,7 @@ class TestQueryResult < MiniTest::Test
           lastName: "Peek",
           company: "GitHub",
           createdAt: Time.at(0),
+          updatedAt: Time.at(1),
           hobbies: ["soccer", "coding"]
         )
       }
@@ -61,7 +68,9 @@ class TestQueryResult < MiniTest::Test
     end
   end
 
-  Schema = GraphQL::Schema.define(query: QueryType)
+  Schema = GraphQL::Schema.define(query: QueryType) do
+    resolve_type -> (_object, _ctx) { PersonType }
+  end
 
   module Temp
   end
@@ -348,6 +357,7 @@ class TestQueryResult < MiniTest::Test
         me {
           name
           createdAt
+          updatedAt
         }
       }
     GRAPHQL
@@ -357,6 +367,7 @@ class TestQueryResult < MiniTest::Test
     person = response.data.me
     assert_equal "Josh", person.name
     assert_equal Time.at(0), person.created_at
+    assert_equal Time.at(1), person.updated_at
   end
 
   include FooHelper


### PR DESCRIPTION
This pull request adds a failing test showcasing what I believe to be a bug in casting custom scalars (`DateTime` in this case) back to a Ruby `DateTime` objects.

The current test strategy asserts that scalars defined on objects are casted appropriately, but when a scalar is defined on an interface, it's casted back as a string, as shown in 608fa6c.

I haven't poked around in the GraphQL Client codebase before today, so I thought I'd start out with a failing test and then investigate how casting works. I'm doing some digging now, but any points in the right direction would be welcomed ❤️.