### PR TITLE
Fix an issue with loading fragments when file and directory names clash.

### DIFF
--- a/test/test_view_module.rb
+++ b/test/test_view_module.rb
@@ -34,20 +34,12 @@ class TestViewModule < MiniTest::Test
     refute GraphQL::Client::ViewModule.valid_constant_name?("404")
   end
 
-  def test_const_path
-    assert_equal "#{Root}/views/users", Views.const_path(:Users)
-    assert_equal "#{Root}/views/users/show.html.erb", Views::Users.const_path(:Show)
-    assert_equal "#{Root}/views/users/_profile.html.erb", Views::Users.const_path(:Profile)
-
-    assert_nil Views.const_path(:Missing)
-  end
-
   def test_const_missing
     assert_kind_of Module, Views::Users
     assert_equal "#{Root}/views/users", Views::Users.path
 
     assert_kind_of Module, Views::Users::Show
-    assert_equal "#{Root}/views/users/show.html.erb", Views::Users::Show.path
+    assert_equal "#{Root}/views/users/show", Views::Users::Show.path
 
     assert_kind_of GraphQL::Client::FragmentDefinition, Views::Users::Show::User
     assert_equal(<<-'GRAPHQL'.gsub("      ", "").chomp, Views::Users::Show::User.document.to_query_string)
@@ -57,6 +49,11 @@ class TestViewModule < MiniTest::Test
     GRAPHQL
 
     assert_kind_of Module, Views::Users::Profile
-    assert_equal "#{Root}/views/users/_profile.html.erb", Views::Users::Profile.path
+    assert_equal "#{Root}/views/users/profile", Views::Users::Profile.path
+    assert_kind_of GraphQL::Client::FragmentDefinition, Views::Users::Profile::User
+
+    assert_kind_of Module, Views::Users::Profile::Show::User
+    assert_equal "#{Root}/views/users/profile/show", Views::Users::Profile::Show.path
+    assert_kind_of GraphQL::Client::FragmentDefinition, Views::Users::Profile::Show::User
   end
 end

--- a/test/views/users/_profile.html.erb
+++ b/test/views/users/_profile.html.erb
@@ -1,0 +1,6 @@
+<%graphql
+  fragment User on User {
+    login
+  }
+%>
+<%= user.login %>

--- a/test/views/users/_profile.html.erb
+++ b/test/views/users/_profile.html.erb
@@ -1,6 +1,8 @@
 <%graphql
   fragment User on User {
     login
+
+    ...TestViewModule::Views::Users::Profile::Show::User
   }
 %>
 <%= user.login %>

--- a/test/views/users/profile/_show.html.erb
+++ b/test/views/users/profile/_show.html.erb
@@ -1,0 +1,6 @@
+<%graphql
+  fragment User on User {
+    login
+  }
+%>
+<%= user.login %>


### PR DESCRIPTION
This fixes an issue where a folder like `app/views/issues/sidebar` would prevent us from loading the fragments defined in `app/views/issues/_sidebar.html.erb` (or `app/views/issues/sidebar.html.erb`).

As part of the changes in here, the meaning of the `path` attribute on `ViewModule`s was modified as well. It now no longer represents the file that a module was loaded from, but instead always is the "lookup path" for where to look for view files when trying to load a missing constant.