### PR TITLE
Recognize symbol to proc access of fields in overfetch RuboCop

### DIFF
--- a/test/views/users/overfetch.html.erb
+++ b/test/views/users/overfetch.html.erb
@@ -2,6 +2,18 @@
   fragment User on User {
     login
     birthday
+
+    posts(first: 10) {
+      edges {
+        node {
+          title
+        }
+      }
+    }
   }
 %>
 <%= user.login %>
+
+<%- user.posts.edges.map(&:node).map(&:title).each do |title| %>
+  <h1><%= title %></h1>
+<%- end %>


### PR DESCRIPTION
As reported in https://github.com/github/graphql-client/issues/92, the `GraphQL/Overfetch` RuboCop does not recognize `Symbol#to_proc` access of fields.

I started with creating a failing test ✌️.

---

Fixes https://github.com/github/graphql-client/issues/92, cc @josh @jes5199