### PR TITLE
Return Enum result objects

### DIFF
--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -265,10 +265,12 @@ class TestSchemaType < MiniTest::Test
     assert_equal "Joshua", person.first_name
     assert_equal "Peek", person.last_name
     assert_equal Time.at(0), person.birthday
-    assert_equal Types::Plan::FREE, person.plan
+    assert_equal true, person.plan.free?
     assert_equal 1, person.friends.length
     assert_equal "2", person.friends[0].id
     assert_equal "David", person.friends[0].name
+
+    assert_same Types::Plan::FREE, person.plan
 
     assert_equal({
       "id" => "1",


### PR DESCRIPTION
:wave: Hi!

As an excuse to get more familiar with the ruby graphql client I thought I'd take a stab at an idea I had for making dedicated enum classes per type. These classes then get instantiated when `cast` is called. This allows for fun things like `person.plan.free?` instead of `Types::Plan::FREE == person.plan`. It's mostly sugar but I thought it might be useful. What do you think?

**Update:**
PR has been updated to return frozen constant instead of value instance, as discussed [below](https://github.com/github/graphql-client/pull/106#issuecomment-303155005). This allows us to just do a minimal number of instantiations but still retain the nice predicate methods.
