### PR TITLE
Fix collocation checks on snakeCased fields

### DIFF
--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -32,7 +32,8 @@ module GraphQL
             define_fields(fields)
 
             if definition.client.enforce_collocated_callers
-              Client.enforce_collocated_callers(self, fields.keys, definition.source_location[0])
+              keys = fields.keys.map { |key| ActiveSupport::Inflector.underscore(key) }
+              Client.enforce_collocated_callers(self, keys, definition.source_location[0])
             end
 
             class << self

--- a/test/foo_helper.rb
+++ b/test/foo_helper.rb
@@ -11,4 +11,8 @@ module FooHelper
   def person_employed?(person)
     person.company?
   end
+
+  def format_person_name(person)
+    "#{person.first_name} #{person.last_name}"
+  end
 end

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -656,6 +656,8 @@ class TestQueryResult < MiniTest::Test
       fragment on Person {
         name
         company
+        firstName
+        lastName
       }
     GRAPHQL
 
@@ -672,6 +674,8 @@ class TestQueryResult < MiniTest::Test
     person = Temp::Person.new(response.data.me)
     assert_equal "Josh", person.name
     assert_equal "GitHub", person.company
+    assert_equal "Joshua", person.first_name
+    assert_equal "Peek", person.last_name
 
     assert_raises GraphQL::Client::NonCollocatedCallerError do
       format_person_info(person)
@@ -683,6 +687,14 @@ class TestQueryResult < MiniTest::Test
 
     GraphQL::Client.allow_noncollocated_callers do
       assert_equal true, person_employed?(person)
+    end
+
+    GraphQL::Client.allow_noncollocated_callers do
+      assert_equal "Joshua Peek", format_person_name(person)
+    end
+
+    assert_raises GraphQL::Client::NonCollocatedCallerError do
+      format_person_name(person)
     end
   end
 


### PR DESCRIPTION
When enforcing collocation, we weren't converting field keys to
underscore, resulting in allowing unchecked access of fields.