### PR TITLE
Add missing require statement

### DIFF
--- a/lib/graphql/client/hash_with_indifferent_access.rb
+++ b/lib/graphql/client/hash_with_indifferent_access.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "active_support/inflector"
+require "forwardable"
 
 module GraphQL
   class Client


### PR DESCRIPTION
Before this fix, when trying to `require 'graphql/client'`, I would get the following error:

```
$ irb
2.2.2 :001 > require 'graphql'
 => true
2.2.2 :002 > require 'graphql/client'
NameError: uninitialized constant GraphQL::Client::HashWithIndifferentAccess::Forwardable
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client/hash_with_indifferent_access.rb:11:in `<class:HashWithIndifferentAccess>'
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client/hash_with_indifferent_access.rb:10:in `<class:Client>'
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client/hash_with_indifferent_access.rb:5:in `<module:GraphQL>'
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client/hash_with_indifferent_access.rb:4:in `<top (required)>'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client/errors.rb:2:in `<top (required)>'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client/schema/object_type.rb:5:in `<top (required)>'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client/definition.rb:5:in `<top (required)>'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /INSTALL-FOLDER/.rvm/gems/ruby-2.2.2/gems/graphql-client-0.11.2/lib/graphql/client.rb:7:in `<top (required)>'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:133:in `require'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from (irb):2
	from /INSTALL-FOLDER/.rvm/rubies/ruby-2.2.2/bin/irb:11:in `
```