### PR TITLE
Handle redirects in HTTP.

### DIFF
--- a/test/test_http.rb
+++ b/test/test_http.rb
@@ -4,34 +4,103 @@ require "graphql/client/http"
 require "minitest/autorun"
 
 class TestHTTP < MiniTest::Test
-  SWAPI = GraphQL::Client::HTTP.new("http://graphql-swapi.parseapp.com/") do
-    def headers(_context)
-      { "User-Agent" => "GraphQL/1.0" }
-    end
+  def setup
+    skip "TestHTTP disabled by default" unless __FILE__ == $PROGRAM_NAME || ENV["TEST_HTTP"]
+    fail "You must specify a valid GITHUB_TOKEN env variable" if ENV["GITHUB_TOKEN"].nil?
   end
 
   def test_execute
-    skip "TestHTTP disabled by default" unless __FILE__ == $PROGRAM_NAME
+    http = GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
+      def headers(_context)
+        { "User-Agent" => "GraphQL/1.0", "Authorization" => "Bearer #{ENV["GITHUB_TOKEN"]}" }
+      end
+    end
 
     document = GraphQL.parse(<<-'GRAPHQL')
-      query getPerson($id: ID!) {
-        person(personID: $id) {
-          name
+      query getRepository($id: ID!) {
+        node(id: $id) {
+          ... on Repository {
+            nameWithOwner
+          }
         }
       }
     GRAPHQL
 
-    name = "getPerson"
-    variables = { "id" => 4 }
+    name = "getRepository"
+    variables = { "id" => "MDEwOlJlcG9zaXRvcnk2NDg3MTI1Ng==" }
 
     expected = {
       "data" => {
-        "person" => {
-          "name" => "Darth Vader"
+        "node" => {
+          "nameWithOwner" => "github/graphql-client"
         }
       }
     }
-    actual = SWAPI.execute(document: document, operation_name: name, variables: variables)
+    actual = http.execute(document: document, operation_name: name, variables: variables)
     assert_equal(expected, actual)
+  end
+
+  def test_follows_redirects
+    http = GraphQL::Client::HTTP.new("https://httpbin.org/redirect-to?url=https%3A%2F%2Fapi.github.com%2Fgraphql") do
+      def headers(_context)
+        { "User-Agent" => "GraphQL/1.0", "Authorization" => "Bearer #{ENV["GITHUB_TOKEN"]}" }
+      end
+    end
+
+    document = GraphQL.parse(<<-'GRAPHQL')
+      query getRepository($id: ID!) {
+        node(id: $id) {
+          ... on Repository {
+            nameWithOwner
+          }
+        }
+      }
+    GRAPHQL
+
+    name = "getRepository"
+    variables = { "id" => "MDEwOlJlcG9zaXRvcnk2NDg3MTI1Ng==" }
+
+    expected = {
+      "data" => {
+        "node" => {
+          "nameWithOwner" => "github/graphql-client"
+        }
+      }
+    }
+    actual = http.execute(document: document, operation_name: name, variables: variables)
+    assert_equal(expected, actual)
+  end
+
+  def test_raises_after_too_many_redirects
+    http = GraphQL::Client::HTTP.new("https://httpbin.org/redirect-to?#{ "url=https://httpbin.org/redirect-to?" * 11 }") do
+      def headers(_context)
+        { "User-Agent" => "GraphQL/1.0", "Authorization" => "Bearer #{ENV["GITHUB_TOKEN"]}" }
+      end
+    end
+
+    document = GraphQL.parse(<<-'GRAPHQL')
+      query getRepository($id: ID!) {
+        node(id: $id) {
+          ... on Repository {
+            nameWithOwner
+          }
+        }
+      }
+    GRAPHQL
+
+    name = "getRepository"
+    variables = { "id" => "MDEwOlJlcG9zaXRvcnk2NDg3MTI1Ng==" }
+
+    expected = {
+      "data" => {
+        "node" => {
+          "nameWithOwner" => "github/graphql-client"
+        }
+      }
+    }
+
+    assert_raises GraphQL::Client::HTTP::TooManyRedirectsError do
+      http.execute(document: document, operation_name: name, variables: variables)
+    end
   end
 end


### PR DESCRIPTION
Also updates the tests to hit the GitHub GraphQL API since the one that was being used by this test doesn't seem to exist anymore.

In order to run these tests, you'll need to set a GITHUB_TOKEN env variable. That should be fine since this test doesn't get run in CI anyway. At some point it might be nice to mock an HTTP service here, but for now I'm just using httpbin.

Fixes https://github.com/github/graphql-client/issues/112

cc @josh 