### PR TITLE
add read_timeout

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -85,6 +85,7 @@ module GraphQL
       def connection
         Net::HTTP.new(uri.host, uri.port).tap do |client|
           client.use_ssl = uri.scheme == "https"
+          client.read_timeout = read_timeout if respond_to? :read_timeout
         end
       end
     end

--- a/test/test_http.rb
+++ b/test/test_http.rb
@@ -10,6 +10,12 @@ class TestHTTP < MiniTest::Test
     end
   end
 
+  SWAPI_TIMEOUT = GraphQL::Client::HTTP.new("https://mpjk0plp9.lp.gql.zone/graphql") do
+    def read_timeout
+      42
+    end
+  end
+
   def test_execute
     skip "TestHTTP disabled by default" unless __FILE__ == $PROGRAM_NAME
 
@@ -33,5 +39,13 @@ class TestHTTP < MiniTest::Test
     }
     actual = SWAPI.execute(document: document, operation_name: name, variables: variables)
     assert_equal(expected, actual)
+  end
+
+  def test_connection
+    actual = SWAPI.connection.read_timeout
+    assert_equal(60, actual)
+
+    actual = SWAPI_TIMEOUT.connection.read_timeout
+    assert_equal(42, actual)
   end
 end


### PR DESCRIPTION
Net::HTTP default read_timeout is 60 seconds, but sometimes you need to wait longer than that.