### PR TITLE
Client Variable Coercion

### DIFF
--- a/lib/graphql/client/schema_input_coercions.rb
+++ b/lib/graphql/client/schema_input_coercions.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require "set"
+
+module GraphQL
+  class Client
+    FALSE_VALUES = [false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF"].to_set.freeze
+
+    SchemaInputCoercions = {}
+
+    SchemaInputCoercions["Boolean"] = ->(value, ctx) {
+      if value == ""
+        nil
+      elsif FALSE_VALUES.include?(value)
+        false
+      else
+        !!value
+      end
+    }
+
+    SchemaInputCoercions["Int"] = ->(value, ctx) {
+      case value
+      when true then 1
+      when false then 0
+      else value.to_i
+      end
+    }
+
+    SchemaInputCoercions["Float"] = ->(value, ctx) {
+      value.to_f
+    }
+
+    SchemaInputCoercions["String"] = ->(value, ctx) {
+      case value
+      when true then "t"
+      when false then "f"
+      else value.to_s
+      end
+    }
+  end
+end

--- a/test/test_variables.rb
+++ b/test/test_variables.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+require "graphql"
+require "graphql/client"
+require "json"
+require "minitest/autorun"
+
+class TestVariables < MiniTest::Test
+  FormatEnumType = GraphQL::EnumType.define do
+    name "Format"
+    value "DESKTOP"
+    value "MOBILE"
+  end
+
+  NestedNestedObjectInput = GraphQL::InputObjectType.define do
+    name "NestedNestedObject"
+    argument :boolean, types.Boolean
+    argument :float, types.Float
+    argument :int, types.Int
+    argument :string, types.String
+  end
+
+  NestedObjectInput = GraphQL::InputObjectType.define do
+    name "NestedObject"
+    argument :boolean, types.Boolean
+    argument :float, types.Float
+    argument :int, types.Int
+    argument :nestedObject, NestedNestedObjectInput
+    argument :string, types.String
+  end
+
+  QueryType = GraphQL::ObjectType.define do
+    name "Query"
+    field :coerce, !types.Boolean do
+      argument :boolean, types.Boolean
+      argument :enum, FormatEnumType
+      argument :float, types.Float
+      argument :int, types.Int
+      argument :nestedObject, NestedObjectInput
+      argument :string, types.String
+      argument :strings, types[types.String]
+    end
+  end
+
+  Schema = GraphQL::Schema.define(query: QueryType)
+  Client = GraphQL::Client.new(schema: Schema, execute: Schema)
+
+  Query = Client.parse <<-'GRAPHQL'
+    query($boolean: Boolean, $enum: Format, $float: Float, $int: Int, $nestedObject: NestedObject, $string: String, $strings: [String]) {
+      coerce(boolean: $boolean, enum: $enum, float: $float, int: $int, nestedObject: $nestedObject, string: $string, strings: $strings)
+    }
+  GRAPHQL
+
+  def test_coerce_boolean
+    assert_equal({ "boolean" => nil }, Client.coerce_variables(Query, { "boolean" => nil }))
+    assert_equal({ "boolean" => nil }, Client.coerce_variables(Query, { "boolean" => "" }))
+
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { boolean: true }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => 1 }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => "1" }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => "t" }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => "T" }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => "true" }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => "TRUE" }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => "on" }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => "ON" }))
+    assert_equal({ "boolean" => true }, Client.coerce_variables(Query, { "boolean" => " " }))
+
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { boolean: false }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => 0 }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => "0" }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => "f" }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => "F" }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => "false" }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => "FALSE" }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => "off" }))
+    assert_equal({ "boolean" => false }, Client.coerce_variables(Query, { "boolean" => "OFF" }))
+  end
+
+  def test_coerce_string
+    assert_equal({ "string" => "42" }, Client.coerce_variables(Query, { "string" => "42" }))
+    assert_equal({ "string" => "42" }, Client.coerce_variables(Query, { string: "42" }))
+    assert_equal({ "string" => "42" }, Client.coerce_variables(Query, { string: 42 }))
+    assert_equal({ "string" => "t" }, Client.coerce_variables(Query, { string: true }))
+    assert_equal({ "string" => "f" }, Client.coerce_variables(Query, { string: false }))
+  end
+
+  def test_coerce_int
+    assert_equal({ "int" => 1 }, Client.coerce_variables(Query, { int: 1 }))
+    assert_equal({ "int" => 1 }, Client.coerce_variables(Query, { "int" => "1" }))
+    assert_equal({ "int" => 1 }, Client.coerce_variables(Query, { "int" => "1ignore" }))
+    assert_equal({ "int" => 0 }, Client.coerce_variables(Query, { "int" => "bad1" }))
+    assert_equal({ "int" => 0 }, Client.coerce_variables(Query, { "int" => "bad" }))
+    assert_equal({ "int" => 1 }, Client.coerce_variables(Query, { "int" => 1.7 }))
+    assert_equal({ "int" => 0 }, Client.coerce_variables(Query, { "int" => false }))
+    assert_equal({ "int" => 1 }, Client.coerce_variables(Query, { "int" => true }))
+    assert_equal({ "int" => nil }, Client.coerce_variables(Query, { "int" => nil }))
+  end
+
+  def test_coerce_float
+    assert_equal({ "float" => 1.0 }, Client.coerce_variables(Query, { float: 1.0 }))
+    assert_equal({ "float" => 1.0 }, Client.coerce_variables(Query, { "float" => 1 }))
+    assert_equal({ "float" => 1.0 }, Client.coerce_variables(Query, { "float" => "1" }))
+    assert_equal({ "float" => nil }, Client.coerce_variables(Query, { "float" => nil }))
+  end
+
+  def test_coerce_null
+    assert_equal({ "string" => nil }, Client.coerce_variables(Query, { "string" => nil }))
+  end
+
+  def test_coerce_list
+    assert_equal({ "strings" => ["foo", "42", "t", nil] }, Client.coerce_variables(Query, { "strings" => ["foo", 42, true, nil] }))
+  end
+
+  def test_coerce_input_object
+    assert_equal(
+      { "nestedObject" => { "string" => "42" } },
+      Client.coerce_variables(Query, { "nestedObject" => { "string" => "42" } })
+    )
+
+    assert_equal(
+      { "nestedObject" => { "string" => "42" } },
+      Client.coerce_variables(Query, { "nestedObject" => { "string" => 42 } })
+    )
+
+    assert_equal(
+      { "nestedObject" => { "boolean" => true, "string" => "42" } },
+      Client.coerce_variables(Query, { "nestedObject" => { "boolean" => true, "string" => 42 } })
+    )
+
+    assert_equal(
+      { "nestedObject" => { "boolean" => true, "string" => "42" } },
+      Client.coerce_variables(Query, { "nestedObject" => { "boolean" => "t", "string" => 42 } })
+    )
+
+    assert_equal(
+      { "nestedObject" => { "nestedObject" => { "string" => "42" } } },
+      Client.coerce_variables(Query, { "nestedObject" => { "nestedObject" => { "string" => 42 } } })
+    )
+  end
+
+  def test_coerce_enum
+    assert_equal({ "enum" => "MOBILE" }, Client.coerce_variables(Query, { "enum" => "MOBILE" }))
+    assert_equal({ "enum" => nil }, Client.coerce_variables(Query, { "enum" => "INVALID" }))
+  end
+end


### PR DESCRIPTION
GraphQL servers perform a strict step of variable coercion after validation. They usually don't let clients pass in strings that should be cast to ints.

Adding a variable validation and coercion step allows for more flexible casting before a request is even made. This supports many of the nice features built into [`ActiveModel::Types`](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/type.rb) like casting `"true"` from web forms into a `true` boolean.

Within Rails apps, the goal is to provide a tool to safely sanitize `params` input and pass along as variables to the GraphQL server.

``` ruby
def graphql_variables
  Client.coerce_variables(params.to_unsafe_h)
end
```

**TODO**

* [ ] Raise a client side validation error if input variables are satisfied. If a non-nullable value is missing or a boolean is given where an list is required, theres not much automatic casting can do.
* [ ] Figure out a better way to register client schema `coerce_input` functions. The current implementation simply patches the `Schema` instance directly. This is probably fine for most remote client cases as the `Client` builds an *owned* instance from a JSON/GraphQL schema file. But if the `Client` is running in the same process as the server schema, mutating the server's copy won't be safe. We might be able to `dump`/`load` to get a deep copy of the schema class.
* [ ] Figure out a better thing to pass into `coerce_input` as `context`.
* [ ] Security audit! These is designed to accept and handle garbage and dangerous user input. Need to assume any value could be given and we *do the right thing*.

##

CC: @rmosolgo @nakajima @tma @mikrobi @cheshire137