### PR TITLE
Add missing words and fix typo

### DIFF
--- a/guides/collocated-call-sites.md
+++ b/guides/collocated-call-sites.md
@@ -117,7 +117,7 @@ def page_title_via_more_indirection(human)
 end
 ```
 
-Instead, declare and explicitly include the dependencies for helper methods that many receive GraphQL data objects. This decouples the `page_title` from changes to the ERB `Human` fragment.
+Instead, declare and explicitly include the dependencies for helper methods that may receive GraphQL data objects. This decouples the `page_title` from changes to the ERB `Human` fragment.
 
 ``` erb
 <%graphql

--- a/guides/unfetched-field-error.md
+++ b/guides/unfetched-field-error.md
@@ -1,6 +1,6 @@
 # GraphQL::Client::UnfetchedFieldError
 
-Raised when trying access a field on a GraphQL response type which hasn't be explicitly queried.
+Raised when trying to access a field on a GraphQL response type which hasn't been explicitly queried.
 
 ``` graphql
 type User {


### PR DESCRIPTION
- Adds a missing `to`
- `be` -> `been`
- `many` -> `may`