### PR TITLE
Normalize type names when creating Ruby classes

### DIFF
--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -53,7 +53,7 @@ module GraphQL
         private
 
         def normalize_type_name(type_name)
-          type_name =~ /^[A-Z]/ ? type_name : type_name.camelize
+          type_name =~ /\A[A-Z]/ ? type_name : type_name.camelize
         end
       end
 

--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -22,7 +22,7 @@ module GraphQL
           when GraphQL::ListType
             define_class(definition, irep_node, type.of_type).to_list_type
           else
-            const_get(type.name).define_class(definition, irep_node)
+            get_class(type.name).define_class(definition, irep_node)
           end
 
           irep_node.ast_node.directives.inject(type_klass) do |klass, directive|
@@ -32,6 +32,28 @@ module GraphQL
               klass
             end
           end
+        end
+
+        def get_class(type_name)
+          const_get(normalize_type_name(type_name))
+        end
+
+        def set_class(type_name, klass)
+          class_name = normalize_type_name(type_name)
+
+          if constants.include?(class_name.to_sym)
+            raise ArgumentError,
+              "Can't define #{class_name} to represent type #{type_name} " \
+              "because it's already defined"
+          end
+
+          const_set(class_name, klass)
+        end
+
+        private
+
+        def normalize_type_name(type_name)
+          type_name =~ /^[A-Z]/ ? type_name : type_name.camelize
         end
       end
 
@@ -48,7 +70,7 @@ module GraphQL
           next if name.start_with?("__")
           if klass = class_for(schema, type, cache)
             klass.schema_module = mod
-            mod.const_set(name, klass)
+            mod.set_class(name, klass)
           end
         end
 

--- a/lib/graphql/client/schema/interface_type.rb
+++ b/lib/graphql/client/schema/interface_type.rb
@@ -22,7 +22,7 @@ module GraphQL
 
         def define_class(definition, irep_node)
           new(irep_node.typed_children.keys.map { |ctype|
-            schema_module.const_get(ctype.name).define_class(definition, irep_node)
+            schema_module.get_class(ctype.name).define_class(definition, irep_node)
           })
         end
       end

--- a/lib/graphql/client/schema/union_type.rb
+++ b/lib/graphql/client/schema/union_type.rb
@@ -22,7 +22,7 @@ module GraphQL
 
         def define_class(definition, irep_node)
           new(irep_node.typed_children.keys.map { |ctype|
-            schema_module.const_get(ctype.name).define_class(definition, irep_node)
+            schema_module.get_class(ctype.name).define_class(definition, irep_node)
           })
         end
       end


### PR DESCRIPTION
`GraphQL::Client::Schema.generate` creates a hierarchy of Ruby modules
and classes based on a GraphQL schema, but Ruby requires constants to
start with a capital letter, which causes problems when types in the
GraphQL schema start with a lowercase letter, as they're allowed to do.

The solution is to convert any lowercase type names into UpperCamelCase
before creating their associated constants. Type names that start with a
capital letter are left alone, so this change shouldn't affect any
schemas that were capable of being parsed by the existing code.

Fixes #123