### PR TITLE
Some execution errors get swallowed

### DIFF
--- a/test/test_catch_all_errors.rb
+++ b/test/test_catch_all_errors.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require "graphql"
+require "graphql/client"
+require "minitest/autorun"
+
+class TestClientErrors < MiniTest::Test
+  InvoiceType = GraphQL::ObjectType.define do
+    name "Invoice"
+    field :fee_in_cents, types.Int
+  end
+
+  QueryType = GraphQL::ObjectType.define do
+    name "Query"
+    field :rescueFromActiveRecordRecordInvalid, InvoiceType do
+      resolve ->(_object, _args, _ctx) {
+        GraphQL::ExecutionError.new "Validation failed: missing fee_in_cents."
+      }
+    end
+  end
+
+  Schema = GraphQL::Schema.define(query: QueryType)
+
+  module Temp
+  end
+
+  def setup
+    @client = GraphQL::Client.new(schema: Schema, execute: Schema)
+  end
+
+  def teardown
+    Temp.constants.each do |sym|
+      Temp.send(:remove_const, sym)
+    end
+  end
+
+  def test_errors_collection
+    Temp.const_set :Query, @client.parse(<<-GRAPHQL
+      query {
+        rescueFromActiveRecordRecordInvalid {
+          fee_in_cents
+        }
+      }
+    GRAPHQL
+    )
+
+    assert response = @client.query(Temp::Query)
+
+    assert_equal 1, response.data.errors.size
+    assert_equal 1, response.data.errors.count
+
+    assert_equal 1, response.errors.size
+    assert_equal 1, response.errors.count
+  end
+end


### PR DESCRIPTION
Spec that reproduces the issue in this PR.
 
The following response produces `errors.any? => false`.

```json
{
  "data": {
    "rescueFromActiveRecordRecordInvalid": null
  },
  "errors": [
    {
      "message": "Validation failed: Fee in cents can't be blank.",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "rescueFromActiveRecordRecordInvalid"
      ]
    }
  ]
}
```

You can try this against https://github.com/dblock/graphql-invoices

```ruby
require "graphql/client"
require "graphql/client/http"

# Star Wars API example wrapper
module API
  HTTP = GraphQL::Client::HTTP.new("http://localhost:3000/graphql")
  Schema = GraphQL::Client.load_schema(HTTP)
  Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
end

CreateInvoiceQuery = API::Client.parse <<-GRAPHQL
  query {
    rescueFromActiveRecordRecordInvalid {
      id
      fee_in_cents
    }
  }
GRAPHQL

result = API::Client.query(CreateInvoiceQuery)

p result

p "ERRORS: #{result.errors.any?}"
```

Looks like a bug. The [GraphQL spec on errors](http://facebook.github.io/graphql/October2016/#sec-Errors) is pretty clear that there should be errors as long as there's a non-empty errors response, but this one gets filtered out in `details`. 

Is this expected? Looks like clients should not rely on `response.errors` and check against `response.data.errors`, in which case what's the point of having it?