### PR TITLE
Update cops to work with newer Rubocops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ gem "actionpack", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
 gem "activesupport", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
 gem "graphql", ENV["GRAPHQL_VERSION"] if ENV["GRAPHQL_VERSION"]
 
-gem "rubocop", "0.47.0"
+group :development, :test do
+  gem "rubocop", "~> 0.51"
+end

--- a/lib/graphql/client/errors.rb
+++ b/lib/graphql/client/errors.rb
@@ -129,7 +129,7 @@ module GraphQL
       # message.
       def each
         return enum_for(:each) unless block_given?
-        messages.keys.each do |field|
+        messages.each_key do |field|
           messages[field].each { |error| yield field, error }
         end
       end

--- a/lib/graphql/client/hash_with_indifferent_access.rb
+++ b/lib/graphql/client/hash_with_indifferent_access.rb
@@ -16,7 +16,7 @@ module GraphQL
         @hash = hash
         @aliases = {}
 
-        hash.keys.each do |key|
+        hash.each_key do |key|
           if key.is_a?(String)
             key_alias = ActiveSupport::Inflector.underscore(key)
             @aliases[key_alias] = key if key != key_alias

--- a/lib/graphql/client/hash_with_indifferent_access.rb
+++ b/lib/graphql/client/hash_with_indifferent_access.rb
@@ -43,6 +43,10 @@ module GraphQL
       alias has_key? key?
       alias member? key?
 
+      def each_key(&block)
+        @hash.each_key { |key| yield convert_value(key) }
+      end
+
       private
 
       def convert_value(key)

--- a/lib/rubocop/cop/graphql/heredoc.rb
+++ b/lib/rubocop/cop/graphql/heredoc.rb
@@ -19,11 +19,11 @@ module RuboCop
           return unless node.location.expression.source =~ /^<<(-|~)?GRAPHQL/
 
           node.each_child_node(:begin) do |begin_node|
-            add_offense(begin_node, :expression, "Do not interpolate variables into GraphQL queries, " \
+            add_offense(begin_node, location: :expression, message: "Do not interpolate variables into GraphQL queries, " \
               "used variables instead.")
           end
 
-          add_offense(node, :expression, "GraphQL heredocs should be quoted. <<-'GRAPHQL'")
+          add_offense(node, location: :expression, message: "GraphQL heredocs should be quoted. <<-'GRAPHQL'")
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/graphql/overfetch.rb
+++ b/lib/rubocop/cop/graphql/overfetch.rb
@@ -44,7 +44,7 @@ module RuboCop
 
           fields.each do |field, count|
             next if count > 0
-            add_offense(nil, ranges[field], "GraphQL field '#{field}' query but was not used in template.")
+            add_offense(nil, location: ranges[field], message: "GraphQL field '#{field}' query but was not used in template.")
           end
         end
 


### PR DESCRIPTION
Newer versions of Rubocop are going to start complaining with:

```
The positional arguments version of Cop#add_offense will be removed in
RuboCop 0.52
/var/lib/jenkins/workspace/github/vendor/gems/2.4.3/ruby/2.4.0/gems/graphql-client-0.12.1/lib/rubocop/cop/graphql/heredoc.rb:22
Warning: The usage of positional location, message, and severity
parameters to Cop#add_offense is deprecated.
Please use keyword arguments instead.
```

This PR prevents those impending errors.