### PR TITLE
Prevent retention of GraphQL::Query instances

### DIFF
--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -28,9 +28,9 @@ module GraphQL
       def initialize(client:, document:, irep_node:, source_location:)
         @client = client
         @document = document
-        @definition_irep_node = irep_node
+        @definition_node = irep_node.ast_node
         @source_location = source_location
-        @schema_class = client.types.define_class(self, definition_irep_node, definition_irep_node.return_type)
+        @schema_class = client.types.define_class(self, irep_node, irep_node.return_type)
       end
 
       # Internal: Get associated owner GraphQL::Client instance.
@@ -41,18 +41,11 @@ module GraphQL
       # GraphQL::Client::Schema::PossibleTypes.
       attr_reader :schema_class
 
-      # Internal: Get underlying IRep Node for the definition.
-      #
-      # Returns GraphQL::InternalRepresentation::Node object.
-      attr_reader :definition_irep_node
-
       # Internal: Get underlying operation or fragment defintion AST node for
       # definition.
       #
       # Returns OperationDefinition or FragmentDefinition object.
-      def definition_node
-        definition_irep_node.ast_node
-      end
+      attr_reader :definition_node
 
       # Public: Global name of definition in client document.
       #


### PR DESCRIPTION
When GraphQL-Client boots, it creates some `GraphQL::Query` instances to validate and process static query strings. 

By accident, these queries are retained in memory even though they aren't needed. Unfortunately, due to graphql-ruby's bloated data structures (😖), these objects can really add up. So, I took a look into how they can be not retained. 

First, I added a hook to the test suite to dump the retained heap after running: 

```ruby 
# graphql/client.rb 
# include fine-grained allocation tracing in the heap dump:
require "objspace"
ObjectSpace.trace_object_allocations_start

# ... 

at_exit {
  # Make sure that unreachable objects are excluded from the heap dump:
  GC.start
  File.open('heap.json', 'w') { |f|
    ObjectSpace.dump_all output: f
  }
}
```

Then, I made a script to pick through the heap dump and figure out which objects were retaining those `GraphQL::Query` instances: 

```ruby
# frozen_string_literal: true
require "json"
require "set"

# These are indexes for objects in the heap,
# We'll use them to jump around later.
$objects_by_address = {}
$objects_by_type = Hash.new { |h,k| h[k] = [] }
$objects_referencing = Hash.new { |h,k| h[k] = [] }

puts "Reading ...."
File.readlines("heap.json").each do |line|
  object = JSON.parse(line)
  address = object["address"]
  type = object["type"]
  # Add this object to the indexes:
  $objects_by_address[address] = object
  $objects_by_type[type] << object
  object["references"]&.each do |ref|
    $objects_referencing[ref] << object
  end
end

# Find the GraphQL::Query instances that were retained
graphql_query_class = $objects_by_type["CLASS"].find { |o| o["name"] == "GraphQL::Query" }
query_objects = $objects_by_type["OBJECT"].select { |o| o["class"] == graphql_query_class["address"] }

# We want to find, what objects cause this query to be retained?
# There are two basic categories of objects that can reference this query:
# - GraphQL::Query internals which reference their parent (eg, GraphQL::Query::Context)
# - Something _else_ ? Which retains a reference, but I don't know why
#
# In the case of the first, keep checking its references to see if that _child_
# object is referenced by a non-internal object.
#
# In the case of the second, print it out so we can learn something about it.
def internal_class_name?(n)
  if n.start_with?("GraphQL::Query::") || n.start_with?("GraphQL::InternalRepresentation") || n.start_with?("GraphQL::Language") || n.start_with?("GraphQL::Schema::Warden")
    # These objects are internal members of a query which retain references to their parent.
    # Keep working from here to see if any external objects are holding on to these.
    true
  elsif n == "Proc" || n == "Hash" || n == "Array" || n == "IMEMO" || n == "Set"
    # These objects are usually internal storage of other objects,
    # keep working through them when you find them.
    true
  else
    # Maybe this object shouldn't have a reference to a Query, log it
    false
  end
end

# Make sure we don't revisit any objects:
$visited_addresses = Set.new
# Accumulate paths to external objects here:
$found_paths = []

# Visit an address, adding it (or its parents) to `$found_paths`
# if you work your way up to an external object.
def visit_address(address, path)
  path = path + [address]
  $visited_addresses.add(address)
  references_to = $objects_referencing[address]
  references_to.each do |referencing_obj|
    referencing_obj_address = referencing_obj["address"]
    if $visited_addresses.include?(referencing_obj_address)
      next
    else
      $visited_addresses.add(referencing_obj_address)
    end
    class_name = $objects_by_address[referencing_obj["class"]]["name"] || referencing_obj["type"]
    if internal_class_name?(class_name)
      # Keep traversing from here
      visit_address(referencing_obj_address, path)
    else
      # This is a non-internal reference to an internal object, what is it?
      puts "Found #{class_name} (#{referencing_obj})"
      $found_paths << (path + [referencing_obj_address])
    end
  end
end

# Visit each retained query object, continuing until you reach an external object
query_objects.each { |q| visit_address(q["address"], []) }

# Dump the found paths
puts "FOUND #{$found_paths.size}:"
$found_paths.each do |found_path|
  puts "*.*.*.*.*." * 20
  found_path.each do |addr|
    obj = $objects_by_address[addr]
    class_name = $objects_by_address[obj["class"]]["name"] || obj["type"]
    puts "#{class_name} -> #{obj}"
    puts "===" * 10
  end
end
```

And it output things like this: 

```
GraphQL::Query -> {"address"=>"0x7fe1dd6a69d8", "type"=>"OBJECT", "class"=>"0x7fe1dd46a1d8", "ivars"=>28, "references"=>["0x7fe1dd5ad108", "0x7fe1dd6a6758", "0x7fe1dd6a66b8", "0x7fe1dd6a60c8", "0x7fe1dd6a60a0", "0x7fe1dd6a6488", "0x7fe1dd6a6460", "0x7fe1dd6a6988", "0x7fe1dd6a6c30", "0x7fe1dd6a6438", "0x7fe1dd6a6398", "0x7fe1dd6b4ba0", "0x7fe1dd1c7408", "0x7fe1dd6a6000", "0x7fe1dd6a6208", "0x7fe1dd6aeed0"], "file"=>"/Users/rmosolgo/code/graphql-client/lib/graphql/client.rb", "line"=>177, "method"=>"new", "generation"=>53, "memsize"=>264, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
==============================
IMEMO -> {"address"=>"0x7fe1dd65e778", "type"=>"IMEMO", "class"=>"0x7fe1dd1ceaa0", "references"=>["0x7fe1dd6b7f80", "0x7fe1dd226c28", "0x7fe1dd6be4e8", "0x7fe1dd6becb8", "0x7fe1dd6bed80", "0x7fe1dd6aed40", "0x7fe1dd6ae480", "0x7fe1dd6a6c30", "0x7fe1dd6a6b40", "0x7fe1dd6a6a78", "0x7fe1dd6a69d8", "0x7fe1dd676800", "0x7fe1dd676378", "0x7fe1dd65e750", "0x7fe1dd65e728", "0x7fe1dd6b7fa8", "0x7fe1dd65e778"], "file"=>"/Users/rmosolgo/code/graphql-client/lib/graphql/client.rb", "line"=>210, "method"=>"lambda", "generation"=>53, "memsize"=>40, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
==============================
IMEMO -> {"address"=>"0x7fe1dd656be0", "type"=>"IMEMO", "class"=>"0x7fe1dd1c6d28", "references"=>["0x7fe1dd6aeed0", "0x7fe1dd6aed40", "0x7fe1dd66fd70", "0x7fe1dd656be0", "0x7fe1dd65e778"], "file"=>"/Users/rmosolgo/code/graphql-client/lib/graphql/client.rb", "line"=>214, "method"=>"lambda", "generation"=>53, "memsize"=>40, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
==============================
Proc -> {"address"=>"0x7fe1dd656bb8", "type"=>"DATA", "class"=>"0x7fe1dd08e1b8", "struct"=>"proc", "references"=>["0x7fe1de379ed0", "0x7fe1dd1c6aa8", "0x7fe1dd656be0"], "file"=>"/Users/rmosolgo/code/graphql-client/lib/graphql/client.rb", "line"=>214, "method"=>"lambda", "generation"=>53, "memsize"=>80, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
==============================
GraphQL::Language::Nodes::OperationDefinition -> {"address"=>"0x7fe1dd6aeed0", "type"=>"OBJECT", "class"=>"0x7fe1dd656c30", "frozen"=>true, "ivars"=>8, "references"=>["0x7fe1dd6b7328", "0x7fe1dd656bb8", "0x7fe1dd6b4ba0", "0x7fe1dd6b4b50", "0x7fe1dd6af128"], "file"=>"parser.y", "line"=>457, "method"=>"new", "generation"=>53, "memsize"=>104, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
==============================
Array -> {"address"=>"0x7fe1de379e80", "type"=>"ARRAY", "class"=>"0x7fe1dd0b4f98", "length"=>3, "embedded"=>true, "references"=>["0x7fe1de371370", "0x7fe1dd6e59f8", "0x7fe1dd6aeed0"], "file"=>"/Users/rmosolgo/code/graphql-client/lib/graphql/client.rb", "line"=>100, "method"=>"initialize", "generation"=>53, "memsize"=>40, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
==============================
GraphQL::Language::Nodes::Document -> {"address"=>"0x7fe1de379e30", "type"=>"OBJECT", "class"=>"0x7fe1dd31eec8", "ivars"=>3, "references"=>["0x7fe1de379e80"], "file"=>"/Users/rmosolgo/code/graphql-client/lib/graphql/client.rb", "line"=>100, "method"=>"new", "generation"=>53, "memsize"=>40, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
==============================
GraphQL::Client -> {"address"=>"0x7fe1de379ed0", "type"=>"OBJECT", "class"=>"0x7fe1dd42b7a8", "ivars"=>7, "references"=>["0x7fe1dd5ad108", "0x7fe1de379e30", "0x7fe1de379de0"], "file"=>"/Users/rmosolgo/code/graphql-client/test/test_client.rb", "line"=>89, "method"=>"new", "generation"=>53, "memsize"=>96, "flags"=>{"wb_protected"=>true, "old"=>true, "uncollectible"=>true, "marked"=>true}}
````

(Showing how the `name = -> { ... }` line contained the query in its closure) 

I used that output to hunt down these references, and freed up about 120mb of retained memory in a GitHub process.



