### PR TITLE
add edge enumeration

### DIFF
--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -545,6 +545,11 @@ class TestQueryResult < MiniTest::Test
     assert_equal "josh", data.users.edges[0].node.login
     assert_equal "mislav", data.users.edges[1].node.login
     assert_equal %w(josh mislav), data.users.edges.map(&:node).map(&:login)
+
+    assert_equal 2, data.users.count
+    assert_equal "josh", data.users.to_a[0].login
+    assert_equal "mislav", data.users.to_a[1].login
+    assert_equal %w(josh mislav), data.users.map(&:login)
   end
 
   def test_enum_values


### PR DESCRIPTION
The goal of this PR is to open a discussion on how to make enumeration of relay connections more pleasant to use. Specifically, we propose turning a response object with an `edges` field into an enumerator of nodes.

At the call site, enumerating over edges currently looks like this:

````ruby
some_items.edges.map(&:node).map(&:some_field)
````

The code in this PR allows the call site to look like this:

````ruby
some_items.map(&:some_field)
````

This is an improvement we've had success using in an internal GraphQL client and we'd like this improvement to exist upstream in this client.

## Regarding implementation.

Though I've successfully tested code equivalent to this PR via monkey patch, I've been unable to test this specific implementation due to encountering a `GraphQL::Client::NonCollocatedCallerError` when I run the test suite.

I would appreciate discussion regarding implementation from those more experienced with the internals of this client.

Would you be interested in accepting an improvement similar to this one upstream?