### PR TITLE
Generate accessors for fields defined in fragments in the same document

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -198,6 +198,7 @@ module GraphQL
           client: self,
           irep_node: irep_node,
           document: sliced_document,
+          source_document: doc,
           source_location: source_location
         )
         definitions[node.name] = definition

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -25,9 +25,10 @@ module GraphQL
         end
       end
 
-      def initialize(client:, document:, irep_node:, source_location:)
+      def initialize(client:, document:, source_document:, irep_node:, source_location:)
         @client = client
         @document = document
+        @source_document = source_document
         @definition_node = irep_node.ast_node
         @source_location = source_location
         @schema_class = client.types.define_class(self, irep_node, irep_node.return_type)
@@ -36,16 +37,22 @@ module GraphQL
       # Internal: Get associated owner GraphQL::Client instance.
       attr_reader :client
 
-      # Internal root schema class for defintion. Returns
+      # Internal root schema class for definition. Returns
       # GraphQL::Client::Schema::ObjectType or
       # GraphQL::Client::Schema::PossibleTypes.
       attr_reader :schema_class
 
-      # Internal: Get underlying operation or fragment defintion AST node for
+      # Internal: Get underlying operation or fragment definition AST node for
       # definition.
       #
       # Returns OperationDefinition or FragmentDefinition object.
       attr_reader :definition_node
+
+      # Internal: Get original document that created this definition, without
+      # any additional dependencies.
+      #
+      # Returns GraphQL::Language::Nodes::Document.
+      attr_reader :source_document
 
       # Public: Global name of definition in client document.
       #

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -22,7 +22,10 @@ module GraphQL
 
         def define_class(definition, irep_node)
           fields = irep_node.typed_children[type].inject({}) { |h, (field_name, field_irep_node)|
-            if definition.indexes[:definitions][field_irep_node.ast_node] == definition.definition_node
+            definition_for_field = definition.indexes[:definitions][field_irep_node.ast_node]
+
+            # Ignore fields defined in other documents.
+            if definition.source_document.definitions.include?(definition_for_field)
               h[field_name.to_sym] = schema_module.define_class(definition, field_irep_node, field_irep_node.definition.type)
             end
             h

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -935,6 +935,23 @@ class TestQueryResult < MiniTest::Test
     assert_equal "josh", owner.login
   end
 
+  def test_parse_fragment_spread_with_local_fragment
+    Temp.const_set :Queries, @client.parse(<<-'GRAPHQL')
+      fragment RepositoryFragment on Repository {
+        name
+      }
+
+      query Query {
+        repository {
+          ...RepositoryFragment
+        }
+      }
+    GRAPHQL
+
+    response = @client.query(Temp::Queries::Query)
+    assert_equal "rails", response.data.repository.name
+  end
+
   def test_supports_unions_with_array_fields
     Temp.const_set :Fragment, @client.parse(<<-'GRAPHQL')
       fragment on IssueOrPullRequest {


### PR DESCRIPTION
In #150, @josh noted it should be possible to access fields from fragments defined in the same document as the operation without using a casting wrapper. That behaviour fulfills the needs we raised in that issue. However, the client doesn't currently work that way – it will generate accessors for only those fields defined in the operation itself.

This patch is a rather brute force way of implementing the described behaviour.

cc @jpittis @jackychiu