### PR TITLE
Fix error handling logic in example

### DIFF
--- a/guides/handling-errors.md
+++ b/guides/handling-errors.md
@@ -58,7 +58,7 @@ class IssuesController < ApplicationController
     # errors object will report these.
     elsif response.errors.any?
       # "Could not resolve to a node with the global id of 'abc'"
-      message = response.data.errors[:issue].join(", ")
+      message = response.errors[:issue].join(", ")
       render status: :internal_server_error, plain: message
     end
   end


### PR DESCRIPTION
We only get to this line if response.data is nil, and the condition indicates response.errors was supposed to be referenced.

----

I am unsure whether this is correct, but the previous one just looked wrong.