### PR TITLE
Add GraphQL::Client::Response#query

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -7,6 +7,7 @@ require "graphql/client/definition_variables"
 require "graphql/client/definition"
 require "graphql/client/error"
 require "graphql/client/errors"
+require "graphql/client/query"
 require "graphql/client/fragment_definition"
 require "graphql/client/operation_definition"
 require "graphql/client/query_typename"
@@ -350,7 +351,8 @@ module GraphQL
         result,
         data: definition.new(data, Errors.new(errors, ["data"])),
         errors: Errors.new(errors),
-        extensions: extensions
+        extensions: extensions,
+        query: Query.new(document: document, operation_name: operation.name, variables: variables, context: context)
       )
     end
 

--- a/lib/graphql/client/query.rb
+++ b/lib/graphql/client/query.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module GraphQL
+  class Client
+    class Query
+      # Public: AST document of the query that was executed.
+      #
+      # Returns instance of GraphQL::Language::Nodes::Document.
+      attr_reader :document
+
+      # Public: Name of the operation that was executed.
+      attr_reader :operation_name
+
+      # Public: Hash with stringed keys of variables used to execute the query.
+      attr_reader :variables
+
+      # Public: Context that was used to execute this query.
+      attr_reader :context
+
+      # Internal: Initialize base class.
+      def initialize(document:, operation_name:, variables:, context:)
+        @document = document
+        @operation_name = operation_name
+        @variables = variables
+        @context = context
+      end
+    end
+  end
+end

--- a/lib/graphql/client/response.rb
+++ b/lib/graphql/client/response.rb
@@ -30,12 +30,16 @@ module GraphQL
       # Public: Hash of server specific extension metadata.
       attr_reader :extensions
 
+      # Public: The query that the response is responding to.
+      attr_reader :query
+
       # Internal: Initialize base class.
-      def initialize(hash, data: nil, errors: Errors.new, extensions: {})
+      def initialize(hash, data: nil, errors: Errors.new, extensions: {}, query:)
         @original_hash = hash
         @data = data
         @errors = errors
         @extensions = extensions
+        @query = query
       end
     end
   end


### PR DESCRIPTION
When using `GraphQL::Client` there are cases where having the original query along side the response is helpful. In those cases, rather than always have to pass both `response` and `query` (and any other query information), I think it would be helpful to expose the original query in the `GraphQL::Client::Response` object.

This is similar to how Rails exposes the original `request` in [`ActionDispatch::Response`](http://api.rubyonrails.org/v5.1/classes/ActionDispatch/Response.html).

I went ahead and added `GraphQL::Client::Query` instead of leveraging `GraphQL::Query` to reduce unnecessary overhead that `GraphQL::Query` might do in its initializer.

cc @bswinnerton