### PR TITLE
Support graphql-ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
   include:
   - rvm: 2.1.10
     env: RAILS_VERSION=4.2.10 GRAPHQL_VERSION=1.6.6
+  - rvm: 2.5.1
+    env: RAILS_VERSION=5.2.0 GRAPHQL_VERSION=1.9-dev
   exclude:
   - rvm: 2.1.10
     env: RAILS_VERSION=5.1.6 GRAPHQL_VERSION=1.6.6

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "actionpack", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
 gem "activesupport", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
 
-graphql_version = ENV["GRAPHQL_VERSION"] == "1.8-dev" ? { github: "rmosolgo/graphql-ruby", tag: "v1.8.0.pre11" } : ENV["GRAPHQL_VERSION"]
+graphql_version = ENV["GRAPHQL_VERSION"] == "1.9-dev" ? { github: "rmosolgo/graphql-ruby", branch: "1.9-dev" } : ENV["GRAPHQL_VERSION"]
 if graphql_version
   gem "graphql", graphql_version
 end

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -229,8 +229,8 @@ module GraphQL
       visitor[Language::Nodes::FragmentSpread].leave << name_hook.method(:rename_node)
       visitor.visit
 
-      if GraphQL::VERSION < "1.9"
-        doc.deep_freeze # 1.9 introduced immutable AST nodes
+      if !doc.respond_to?(:merge)
+        doc.deep_freeze # 1.9 introduced immutable AST nodes, so we skip this on 1.9+
       end
 
       if document_tracking_enabled

--- a/lib/graphql/client/query_typename.rb
+++ b/lib/graphql/client/query_typename.rb
@@ -13,33 +13,88 @@ module GraphQL
       # document - GraphQL::Language::Nodes::Document to modify
       # schema - Optional Map of GraphQL::Language::Nodes::Node to GraphQL::Type
       #
-      # Returns nothing.
-      def self.insert_typename_fields(document, types: {})
-        on_selections = ->(node, _parent) do
-          type = types[node]
+      # Returns the document with `__typename` added to it
+      if GraphQL::Language::Nodes::AbstractNode.method_defined?(:merge)
+        # GraphQL 1.9 introduces a new visitor class
+        # and doesn't expose writer methods for node attributes.
+        # So, use the node mutation API instead.
+        class InsertTypenameVisitor < GraphQL::Language::Visitor
+          def initialize(document, types:)
+            @types = types
+            super(document)
+          end
 
-          if node.selections.any?
-            case type && type.unwrap
-            when NilClass, GraphQL::InterfaceType, GraphQL::UnionType
-              names = node_flatten_selections(node.selections).map { |s| s.respond_to?(:name) ? s.name : nil }
-              names = Set.new(names.compact)
+          def add_typename(node, parent)
+            type = @types[node]
+            p type
+            if node.selections.any?
+              case type && type.unwrap
+              when NilClass, GraphQL::InterfaceType, GraphQL::UnionType
+                names = QueryTypename.node_flatten_selections(node.selections).map { |s| s.respond_to?(:name) ? s.name : nil }
+                names = Set.new(names.compact)
 
-              unless names.include?("__typename")
-                node.selections = [GraphQL::Language::Nodes::Field.new(name: "__typename")] + node.selections
+                if names.include?("__typename")
+                  yield(node, parent)
+                else
+                  node_with_typename = node.merge(selections: [GraphQL::Language::Nodes::Field.new(name: "__typename")] + node.selections)
+                  yield(node_with_typename, parent)
+                end
+              else
+                yield(node, parent)
               end
+            elsif type && type.unwrap.is_a?(GraphQL::ObjectType)
+              node_with_typename = node.merge(selections: [GraphQL::Language::Nodes::Field.new(name: "__typename")] + node.selections)
+              yield(node_with_typename, parent)
             end
-          elsif type && type.unwrap.is_a?(GraphQL::ObjectType)
-            node.selections = [GraphQL::Language::Nodes::Field.new(name: "__typename")]
+          end
+
+          def on_field(node, parent)
+            add_typename(node, parent) { |n, p| super(n, p) }
+          end
+
+          def on_inline_fragment(node, parent)
+            add_typename(node, parent) { |n, p| super(n, p) }
+          end
+
+          def on_fragment_definition(node, parent)
+            add_typename(node, parent) { |n, p| super(n, p) }
           end
         end
 
-        visitor = GraphQL::Language::Visitor.new(document)
-        visitor[GraphQL::Language::Nodes::Field].leave << on_selections
-        visitor[GraphQL::Language::Nodes::FragmentDefinition].leave << on_selections
-        visitor[GraphQL::Language::Nodes::OperationDefinition].leave << on_selections
-        visitor.visit
+        def self.insert_typename_fields(document, types: {})
+          visitor = InsertTypenameVisitor.new(document, types: types)
+          visitor.visit
+          visitor.result
+        end
 
-        nil
+      else
+        def self.insert_typename_fields(document, types: {})
+          on_selections = ->(node, _parent) do
+            type = types[node]
+
+            if node.selections.any?
+              case type && type.unwrap
+              when NilClass, GraphQL::InterfaceType, GraphQL::UnionType
+                names = node_flatten_selections(node.selections).map { |s| s.respond_to?(:name) ? s.name : nil }
+                names = Set.new(names.compact)
+
+                unless names.include?("__typename")
+                  node.selections = [GraphQL::Language::Nodes::Field.new(name: "__typename")] + node.selections
+                end
+              end
+            elsif type && type.unwrap.is_a?(GraphQL::ObjectType)
+              node.selections = [GraphQL::Language::Nodes::Field.new(name: "__typename")]
+            end
+          end
+
+          visitor = GraphQL::Language::Visitor.new(document)
+          visitor[GraphQL::Language::Nodes::Field].leave << on_selections
+          visitor[GraphQL::Language::Nodes::FragmentDefinition].leave << on_selections
+          visitor[GraphQL::Language::Nodes::OperationDefinition].leave << on_selections
+          visitor.visit
+
+          document
+        end
       end
 
       def self.node_flatten_selections(selections)

--- a/lib/graphql/client/schema/possible_types.rb
+++ b/lib/graphql/client/schema/possible_types.rb
@@ -41,7 +41,7 @@ module GraphQL
             if type = possible_types[typename]
               type.cast(value, errors)
             else
-              raise InvariantError, "expected value to be one of (#{possible_types.keys.join(", ")}), but was #{typename}"
+              raise InvariantError, "expected value to be one of (#{possible_types.keys.join(", ")}), but was #{typename.inspect}"
             end
           when NilClass
             nil

--- a/lib/graphql/language/nodes/deep_freeze_ext.rb
+++ b/lib/graphql/language/nodes/deep_freeze_ext.rb
@@ -10,6 +10,7 @@ module GraphQL
         #
         # Returns self Node.
         def deep_freeze
+          scalars # load internal state
           children.each(&:deep_freeze)
           scalars.each { |s| s && s.freeze }
           freeze

--- a/test/test_query_typename.rb
+++ b/test/test_query_typename.rb
@@ -133,7 +133,7 @@ class TestQueryTypename < MiniTest::Test
   end
 
   def test_insert_typename
-    @document = GraphQL::Client::QueryTypename.insert_typename_fields(@document)
+    document = GraphQL::Client::QueryTypename.insert_typename_fields(@document)
 
     expected = <<-'GRAPHQL'
       query FooQuery {
@@ -189,12 +189,12 @@ class TestQueryTypename < MiniTest::Test
         id
       }
     GRAPHQL
-    assert_equal expected.gsub(/^      /, "").chomp, @document.to_query_string
+    assert_equal expected.gsub(/^      /, "").chomp, document.to_query_string
   end
 
   def test_insert_schema_aware_typename
     types = GraphQL::Client::DocumentTypes.analyze_types(Schema, @document)
-    @document = GraphQL::Client::QueryTypename.insert_typename_fields(@document, types: types)
+    document = GraphQL::Client::QueryTypename.insert_typename_fields(@document, types: types)
 
     expected = <<-'GRAPHQL'
       query FooQuery {
@@ -243,7 +243,7 @@ class TestQueryTypename < MiniTest::Test
         id
       }
     GRAPHQL
-    assert_equal expected.gsub(/^      /, "").chomp, @document.to_query_string
+    assert_equal expected.gsub(/^      /, "").chomp, document.to_query_string
   end
 
   def test_insert_typename_on_empty_selections
@@ -254,7 +254,7 @@ class TestQueryTypename < MiniTest::Test
     GRAPHQL
 
     types = GraphQL::Client::DocumentTypes.analyze_types(Schema, document)
-    @document = GraphQL::Client::QueryTypename.insert_typename_fields(document, types: types)
+    document = GraphQL::Client::QueryTypename.insert_typename_fields(document, types: types)
 
     expected = <<-'GRAPHQL'
       query FooQuery {

--- a/test/test_query_typename.rb
+++ b/test/test_query_typename.rb
@@ -133,7 +133,7 @@ class TestQueryTypename < MiniTest::Test
   end
 
   def test_insert_typename
-    GraphQL::Client::QueryTypename.insert_typename_fields(@document)
+    @document = GraphQL::Client::QueryTypename.insert_typename_fields(@document)
 
     expected = <<-'GRAPHQL'
       query FooQuery {
@@ -194,7 +194,7 @@ class TestQueryTypename < MiniTest::Test
 
   def test_insert_schema_aware_typename
     types = GraphQL::Client::DocumentTypes.analyze_types(Schema, @document)
-    GraphQL::Client::QueryTypename.insert_typename_fields(@document, types: types)
+    @document = GraphQL::Client::QueryTypename.insert_typename_fields(@document, types: types)
 
     expected = <<-'GRAPHQL'
       query FooQuery {
@@ -254,7 +254,7 @@ class TestQueryTypename < MiniTest::Test
     GRAPHQL
 
     types = GraphQL::Client::DocumentTypes.analyze_types(Schema, document)
-    GraphQL::Client::QueryTypename.insert_typename_fields(document, types: types)
+    @document = GraphQL::Client::QueryTypename.insert_typename_fields(document, types: types)
 
     expected = <<-'GRAPHQL'
       query FooQuery {


### PR DESCRIPTION
GraphQL-Ruby 1.9 has two relevant changes: 

- AST nodes are [immutable-ish by default](https://github.com/rmosolgo/graphql-ruby/pull/1338)
- There's a new class-based visitor that allows you to [modify the original document](https://github.com/rmosolgo/graphql-ruby/pull/1740)

So, here, I'm trying to add 1.9-dev to the build matrix. It looks like GraphQL-Ruby's `replace_child` is broken for inline fragments at least tho.