### PR TITLE
generated request body in execution context

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -60,15 +60,18 @@ module GraphQL
 
         request.basic_auth(uri.user, uri.password) if uri.user || uri.password
 
-        request["Accept"] = "application/json"
-        request["Content-Type"] = "application/json"
-        headers(context).each { |name, value| request[name] = value }
-
         body = {}
         body["query"] = document.to_query_string
         body["variables"] = variables if variables.any?
         body["operationName"] = operation_name if operation_name
-        request.body = JSON.generate(body)
+        request_body = JSON.generate(body)
+        context["request_body"] = request_body
+
+        request.body = request_body
+
+        request["Accept"] = "application/json"
+        request["Content-Type"] = "application/json"
+        headers(context).each { |name, value| request[name] = value }
 
         response = connection.request(request)
         case response

--- a/test/test_http.rb
+++ b/test/test_http.rb
@@ -4,14 +4,20 @@ require "graphql/client/http"
 require "minitest/autorun"
 
 class TestHTTP < MiniTest::Test
+  CONTEXT_USER = Minitest::Mock.new
+
   SWAPI = GraphQL::Client::HTTP.new("https://mpjk0plp9.lp.gql.zone/graphql") do
-    def headers(_context)
+    def headers(context)
+      request_json_fields = Hash(JSON.parse(context["request_body"])).keys
+      CONTEXT_USER.use_body(request_json_fields)
       { "User-Agent" => "GraphQL/1.0" }
     end
   end
 
   def test_execute
     skip "TestHTTP disabled by default" unless __FILE__ == $PROGRAM_NAME
+
+    CONTEXT_USER.expect(:use_body, nil, [%w[query variables operationName]])
 
     document = GraphQL.parse(<<-'GRAPHQL')
       query getCharacter($id: ID!) {
@@ -33,5 +39,6 @@ class TestHTTP < MiniTest::Test
     }
     actual = SWAPI.execute(document: document, operation_name: name, variables: variables)
     assert_equal(expected, actual)
+    assert(CONTEXT_USER.verify)
   end
 end


### PR DESCRIPTION
Hi,

I needed to generate a JWT header and for that I needed the request body so I rearranged the `execute` method a bit and set the `request_body` key on the context hash that I could then use in the headers method. There is also a change in the test of the `HTTP` class.
The change is not big but the question is does it fit with your plans, your style and would you be willing to merge something like that upstream.
