### PR TITLE
Remove Client duplication in http.rb docs

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -7,7 +7,7 @@ module GraphQL
   class Client
     # Public: Basic HTTP network adapter.
     #
-    #   GraphQL::Client::Client.new(
+    #   GraphQL::Client.new(
     #     execute: GraphQL::Client::HTTP.new("http://graphql-swapi.parseapp.com/")
     #   )
     #


### PR DESCRIPTION
In the `http.rb` documentation, it says to use `GraphQL::Client::Client`, but that constant does not exist. There is only `GraphQL::Client`.