### PR TITLE
Remove the upperbound constraint on ActiveSupport:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,14 @@ env:
   - RAILS_VERSION=5.1.6 GRAPHQL_VERSION=1.8.11
   - RAILS_VERSION=5.1.6
   - RAILS_VERSION=5.2.0
+  - RAILS_VERSION=edge
 
 matrix:
   include:
   - rvm: 2.5.1
     env: RAILS_VERSION=5.2.0 GRAPHQL_VERSION=1.9-dev
+  exclude:
+  - rvm: 2.4.4
+    env: RAILS_VERSION=edge
+  - rvm: 2.3.7
+    env: RAILS_VERSION=edge

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@
 source "https://rubygems.org"
 gemspec
 
-gem "actionpack", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
-gem "activesupport", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
+rails_version = ENV["RAILS_VERSION"] == "edge" ? { github: "rails/rails" } : ENV["RAILS_VERSION"]
+gem "actionpack", rails_version
+gem "activesupport", rails_version
 
 graphql_version = ENV["GRAPHQL_VERSION"] == "1.9-dev" ? { github: "rmosolgo/graphql-ruby", branch: "1.9-dev" } : ENV["GRAPHQL_VERSION"]
 if graphql_version

--- a/graphql-client.gemspec
+++ b/graphql-client.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
 
-  s.add_dependency "activesupport", ">= 3.0", "< 6.0"
+  s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "graphql", "~> 1.8"
 
-  s.add_development_dependency "actionpack", ">= 3.2.22", "< 6.0"
+  s.add_development_dependency "actionpack", ">= 3.2.22"
   s.add_development_dependency "erubi", "~> 1.6"
   s.add_development_dependency "erubis", "~> 2.7"
   s.add_development_dependency "minitest", "~> 5.9"

--- a/test/test_erb.rb
+++ b/test/test_erb.rb
@@ -35,7 +35,7 @@ class TestERB < MiniTest::Test
 
     erb = GraphQL::Client::ERB.new(src)
 
-    output_buffer = ActionView::OutputBuffer.new
+    output_buffer = @output_buffer = ActionView::OutputBuffer.new
     # rubocop:disable Security/Eval
     eval(erb.src, binding, "(erb)")
     assert_equal "42", output_buffer.strip


### PR DESCRIPTION
Remove the upperbound constraint on ActiveSupport:

- During every ActiveSupport major bump, this gemspec needs to be updated,
  I think we are being too conservative and having an upperbound limit
  doesn't help.

  If we wanted to be really conservative we would have to add a
  upperbound constraint on the minor version as well (< 5.x.x) since
  Rails doesn't follow semver and minor version can introduce breaking
  changes.

  What I think is better is to remove the upperbound constraint,
  and test graphql-client directly on ActiveSupport edge.