### PR TITLE
Try the graphql-ruby 1.9.0 release candidate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "actionpack", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
 gem "activesupport", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
 
-graphql_version = ENV["GRAPHQL_VERSION"] == "1.9-dev" ? { github: "rmosolgo/graphql-ruby", branch: "1.9-dev" } : ENV["GRAPHQL_VERSION"]
+graphql_version = ENV["GRAPHQL_VERSION"] == "1.9-dev" ? "1.9.0.pre3" : ENV["GRAPHQL_VERSION"]
 if graphql_version
   gem "graphql", graphql_version
 end


### PR DESCRIPTION
I want to make sure that the new release won't break this gem.