### PR TITLE
Check for spreads inclusion when using interfaces as well

### DIFF
--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -110,14 +110,7 @@ module GraphQL
           when NilClass
             obj
           else
-            if obj.class.is_a?(GraphQL::Client::Schema::ObjectType)
-              unless obj.class._spreads.include?(definition_node.name)
-                raise TypeError, "#{definition_node.name} is not included in #{obj.class.source_definition.name}"
-              end
-              schema_class.cast(obj.to_h, obj.errors)
-            else
-              raise TypeError, "unexpected #{obj.class}"
-            end
+            cast_object(obj)
           end
         when GraphQL::Client::Schema::ObjectType
           case obj
@@ -126,14 +119,7 @@ module GraphQL
           when Hash
             schema_class.new(obj, errors)
           else
-            if obj.class.is_a?(GraphQL::Client::Schema::ObjectType)
-              unless obj.class._spreads.include?(definition_node.name)
-                raise TypeError, "#{definition_node.name} is not included in #{obj.class.source_definition.name}"
-              end
-              schema_class.cast(obj.to_h, obj.errors)
-            else
-              raise TypeError, "unexpected #{obj.class}"
-            end
+            cast_object(obj)
           end
         else
           raise TypeError, "unexpected #{schema_class}"
@@ -152,6 +138,18 @@ module GraphQL
       end
 
       private
+
+        def cast_object(obj)
+          if obj.class.is_a?(GraphQL::Client::Schema::ObjectType)
+            unless obj.class._spreads.include?(definition_node.name)
+              raise TypeError, "#{definition_node.name} is not included in #{obj.class.source_definition.name}"
+            end
+            schema_class.cast(obj.to_h, obj.errors)
+          else
+            raise TypeError, "unexpected #{obj.class}"
+          end
+        end
+
         def index_spreads(visitor)
           spreads = {}
           on_node = ->(node, _parent) { spreads[node] = Set.new(flatten_spreads(node).map(&:name)) }

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -108,7 +108,7 @@ module GraphQL
         when GraphQL::Client::Schema::PossibleTypes
           case obj
           when NilClass
-            nil
+            obj
           else
             if obj.class.is_a?(GraphQL::Client::Schema::ObjectType)
               unless obj.class._spreads.include?(definition_node.name)

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -110,7 +110,14 @@ module GraphQL
           when NilClass
             nil
           else
-            schema_class.cast(obj.to_h, obj.errors)
+            if obj.class.is_a?(GraphQL::Client::Schema::ObjectType)
+              unless obj.class._spreads.include?(definition_node.name)
+                raise TypeError, "#{definition_node.name} is not included in #{obj.class.source_definition.name}"
+              end
+              schema_class.cast(obj.to_h, obj.errors)
+            else
+              raise TypeError, "unexpected #{obj.class}"
+            end
           end
         when GraphQL::Client::Schema::ObjectType
           case obj

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -1038,9 +1038,30 @@ class TestQueryResult < MiniTest::Test
 
     response = @client.query(Temp::Query)
 
-    assert_raises TypeError,  "TestQueryResult::Temp::AdminFragment is not included in TestQueryResult::Temp::Query" do
+    assert_raises TypeError, "TestQueryResult::Temp::AdminFragment is not included in TestQueryResult::Temp::Query" do
       Temp::AdminFragment.new(response.data.node)
     end
+  end
+
+  def test_parse_valid_fragment_cast_on_spread
+    Temp.const_set :AdminFragment, @client.parse(<<-'GRAPHQL')
+      fragment on AdminUser {
+        password
+      }
+    GRAPHQL
+
+    Temp.const_set :Query, @client.parse(<<-'GRAPHQL')
+      {
+        node(id: "1") {
+          ...TestQueryResult::Temp::AdminFragment
+        }
+      }
+    GRAPHQL
+
+    response = @client.query(Temp::Query)
+    admin = Temp::AdminFragment.new(response.data.node)
+
+    assert_equal "secret", admin.password
   end
 
   def test_client_parse_fragment_query_result_with_inline_fragments

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -1021,6 +1021,28 @@ class TestQueryResult < MiniTest::Test
     end
   end
 
+  def test_parse_invalid_fragment_cast_on_spread
+    Temp.const_set :AdminFragment, @client.parse(<<-'GRAPHQL')
+      fragment on AdminUser {
+        password
+      }
+    GRAPHQL
+
+    Temp.const_set :Query, @client.parse(<<-'GRAPHQL')
+      {
+        node(id: "1") {
+          id
+        }
+      }
+    GRAPHQL
+
+    response = @client.query(Temp::Query)
+
+    assert_raises TypeError,  "TestQueryResult::Temp::AdminFragment is not included in TestQueryResult::Temp::Query" do
+      Temp::AdminFragment.new(response.data.node)
+    end
+  end
+
   def test_client_parse_fragment_query_result_with_inline_fragments
     Temp.const_set :UserFragment, @client.parse(<<-'GRAPHQL')
       fragment on User {


### PR DESCRIPTION
We noticed that when a fragment is defined on an interface and then spread into a query, we weren't checking to make sure that the fragment was included in the query when initializing a new object.  This can lead to some unexpected behavior, type errors, and inconsistencies.  This PR fixes that by: adding the same checks that are made for `ObjectType`, refactors to DRY up the logic a bit, and adds some tests around this behavior.

For a good illustration of the problem in its minimal form check out this test: https://github.com/github/graphql-client/compare/check-spreads?expand=1#diff-97ee885c14874ef10b6b04005d91d844R1024

Thank you!