### PR TITLE
Use a String delegator rather than define lots of methods on string instances

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -14,6 +14,7 @@ require "graphql/client/response"
 require "graphql/client/schema"
 require "graphql/language/nodes/deep_freeze_ext"
 require "json"
+require "delegate"
 
 module GraphQL
   # GraphQL Client helps build and execute queries against a GraphQL backend.

--- a/lib/graphql/client/schema/enum_type.rb
+++ b/lib/graphql/client/schema/enum_type.rb
@@ -9,6 +9,34 @@ module GraphQL
       class EnumType < Module
         include BaseType
 
+        class EnumValue < DelegateClass(String)
+          def initialize(obj, enum_value, enum)
+            super(obj)
+            @enum_value = enum_value
+            @enum = enum
+          end
+
+          def respond_to_missing?(method_name, include_private = false)
+            if method_name[-1] == '?' && @enum.include?(method_name[0..-2])
+              true
+            else
+              super
+            end
+          end
+
+          def method_missing(method_name, *args)
+            if method_name[-1] == '?'
+              queried_value = method_name[0..-2]
+              if @enum.include?(queried_value)
+                raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)" unless args.empty?
+                return @enum_value == queried_value
+              end
+            end
+
+            super
+          end
+        end
+
         # Internal: Construct enum wrapper from another GraphQL::EnumType.
         #
         # type - GraphQL::EnumType instance
@@ -21,16 +49,12 @@ module GraphQL
           @values = {}
 
           all_values = type.values.keys
+          comparison_set = all_values.map { |s| -s.downcase }.to_set
 
           all_values.each do |value|
-            str = value.dup
-            all_values.each do |v|
-              str.define_singleton_method("#{v.downcase}?") { false }
-            end
-            str.define_singleton_method("#{value.downcase}?") { true }
-            str.freeze
+            str = EnumValue.new(-value, -value.downcase, comparison_set).freeze
             const_set(value, str) if value =~ /^[A-Z]/
-            @values[str] = str
+            @values[str.to_s] = str
           end
 
           @values.freeze


### PR DESCRIPTION
While running `memory_profiler` against our application I noticed graphql-client was retaining a surprising amount of memory:

```
retained memory by gem
-----------------------------------
  11.69 MB  graphql-client-0.14.0

retained memory by location
-----------------------------------
  11.22 MB  /tmp/bundle/ruby/2.5.0/gems/graphql-client-0.14.0/lib/graphql/client/schema/enum_type.rb:28
```

After looking at the source of these objects it's pretty clear what's happening.

Each enum values (`String` instances) get some methods defined on it's singleton_class. So for an enum with `N` values, it creates `N` singleton classes, and `N**2` methods. This quickly amount of a lot of memory if you load some moderately complex schemas.

### Solution

Rather than to define methods on the string instances, I use a delegator with `method_missing`. On paper it's marginally slower than a precompiled method, so it's trading CPU for RAM, but I don't think the small performance win is really worth that much RAM.

### Patch effect

After applying this patch on top of `0.14.0` the profile now look like this:

```
retained memory by gem
-----------------------------------
 435.07 kB  graphql-client-7ac207923e55
```

So that's a 96% reduction in memory usage. Also the number of retaiend objects went down from `97244  graphql-client-0.14.0` to ` 2761  graphql-client-7ac207923e55`, which is a 97% reduction.

cc @csfrancis
