### PR TITLE
Cache object_type method generation in a module

### DIFF
--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -95,9 +95,9 @@ module GraphQL
           name = name.to_s
           method_name = ActiveSupport::Inflector.underscore(name)
 
-          ctx.define_method(method_name, &METHOD_CACHE[key])
+          ctx.send(:define_method, method_name, &METHOD_CACHE[key])
 
-          ctx.define_method("#{method_name}?", &PREDICATE_CACHE[name])
+          ctx.send(:define_method, "#{method_name}?", &PREDICATE_CACHE[name])
         end
 
         def define_field(name, type)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -82,20 +82,20 @@ module GraphQL
 
         def define_fields(fields)
           const_set :FIELDS, fields
-          this = self
           mod = MODULE_CACHE[fields.keys.sort] ||= Module.new do
-            fields.each { |name, type| this.define_cached_field(name, type, self) }
+            fields.each do |name, type|
+              GraphQL::Client::Schema::ObjectType.define_cached_field(name, type, self)
+            end
           end
           include mod
         end
 
-        def define_cached_field(name, type, ctx)
+        def self.define_cached_field(name, type, ctx)
           key = name
           name = name.to_s
           method_name = ActiveSupport::Inflector.underscore(name)
 
           ctx.send(:define_method, method_name, &METHOD_CACHE[key])
-
           ctx.send(:define_method, "#{method_name}?", &PREDICATE_CACHE[name])
         end
 

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -87,7 +87,6 @@ module GraphQL
             fields.each { |name, type| this.define_cached_field(name, type, self) }
           end
           include mod
-          #fields.each { |name, type| define_cached_field(name, type, self) }
         end
 
         def define_cached_field(name, type, ctx)


### PR DESCRIPTION
This commit caches method generation in a module with the hopes of
reducing object allocations when many classes are generated.