### PR TITLE
Add "context" for dump_schema

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -70,7 +70,7 @@ module GraphQL
 
     IntrospectionDocument = GraphQL.parse(GraphQL::Introspection::INTROSPECTION_QUERY).deep_freeze
 
-    def self.dump_schema(schema, io = nil)
+    def self.dump_schema(schema, io = nil, context: {})
       unless schema.respond_to?(:execute)
         raise TypeError, "expected schema to respond to #execute(), but was #{schema.class}"
       end
@@ -79,7 +79,7 @@ module GraphQL
         document: IntrospectionDocument,
         operation_name: "IntrospectionQuery",
         variables: {},
-        context: {}
+        context: context
       ).to_h
 
       if io


### PR DESCRIPTION
## Problem

The GraphQL API we're calling has a token auth. The information to generate the token (for example the `user`) is passed via `context`. Example:

```ruby
  HTTP = GraphQL::Client::HTTP.new("https://api.text/") do
    def headers(context)
      # Optionally set any HTTP headers
      token = generate_token_for_user(context[:user])
      { "Authorization": "Bearer #{token}" }
    end
  end  
```

And we want to automate the task that dumps the schema. However, the `dump_schema` method doesn't have a `context` parameter, even though it passes an empty context internally.

So that we can properly run the auth and dump the schema:

```ruby
GraphQL::Client.dump_schema(SWAPI::HTTP, "path/to/schema.json", context: {user: user})
```

## Solution

This PR adds an optional `context` parameter for the `dump_schema` method.