### PR TITLE
Eliminate lazy lambdas

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -253,7 +253,7 @@ module GraphQL
         definition = @definitions[node.name]
         if definition
           node.extend(LazyName)
-          node.name_proc = -> { definition.definition_name }
+          node._definition = definition
         end
       end
     end
@@ -376,10 +376,10 @@ module GraphQL
     # name to point to a lazily defined Proc instead of a static string.
     module LazyName
       def name
-        @name_proc.call
+        @_definition.definition_name
       end
 
-      attr_writer :name_proc
+      attr_writer :_definition
     end
 
     private


### PR DESCRIPTION
We can just directly assign the "definition" object and have the new
`name` method call the definition object.  This doesn't save many
objects, but I found that the average size of the lambdas was fairly
large.  This saved about 800k total memsize.

```
$ jq .memsize heap-old.json | awk '{s+=$1} END {print s}'
525218081
$ jq .memsize heap-now.json | awk '{s+=$1} END {print s}'
524342452
$ wc -l heap-old.json
 4249093 heap-old.json
$ wc -l heap-now.json
 4242347 heap-now.json
```

Memsize saving:

```
$ ruby -e'p 525218081 - 524342452'
875629
```

Object Reduction:

```
$ ruby -e'p 4249093 - 4242347'
6746
```