### PR TITLE
Remove the `schema` method

### DIFF
--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -70,10 +70,6 @@ module GraphQL
         mod = Module.new
         mod.extend ClassMethods
 
-        mod.define_singleton_method :schema do
-          schema
-        end
-
         cache = {}
         schema.types.each do |name, type|
           next if name.start_with?("__")

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -73,10 +73,6 @@ class TestSchemaType < MiniTest::Test
 
   Types = GraphQL::Client::Schema.generate(Schema)
 
-  def test_schema
-    assert_equal Schema, Types.schema
-  end
-
   def test_query_object_class
     assert_equal QueryType, Types::Query.type
     assert_equal "TestSchemaType::Types::Query", Types::Query.inspect


### PR DESCRIPTION
I don't think this method is actually used, and the lambda used to
create the method holds a reference to the `cache` hash which can grow
large.