### PR TITLE
Immediately extend `ObjectClass` with class level readers

### DIFF
--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -19,11 +19,6 @@ module GraphQL
           end
         end
 
-        module ClassMethods
-          attr_reader :source_definition
-          attr_reader :_spreads
-        end
-
         def define_class(definition, ast_nodes)
           # First, gather all the ast nodes representing a certain selection, by name.
           # We gather AST nodes into arrays so that multiple selections can be grouped, for example:
@@ -53,7 +48,6 @@ module GraphQL
 
           klass = Class.new(self)
           klass.define_fields(field_classes)
-          klass.extend(ClassMethods)
           klass.instance_variable_set(:@source_definition, definition)
           klass.instance_variable_set(:@_spreads, definition.indexes[:spreads][ast_nodes.first])
 
@@ -181,6 +175,13 @@ module GraphQL
       end
 
       class ObjectClass
+        module ClassMethods
+          attr_reader :source_definition
+          attr_reader :_spreads
+        end
+
+        extend ClassMethods
+
         def initialize(data = {}, errors = Errors.new)
           @data = data
           @casted_data = {}


### PR DESCRIPTION
Metaclasses are lazily created, and extending the new class each time
will create the metaclass.  These classes seem to always bee instances
of `ObjectClass`, so if we add the class methods to `ObjectClass` then
we'll always have the correct class methods, but never need the
metaclass to be instantiated.

This saved about 250k allocations:

```
$ wc -l heap-before.json
 3280346 heap-before.json
$ wc -l heap-after.json
 3037087 heap-after.json
 ```