### PR TITLE
Clear indexes cache after defining classes

### DIFF
--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -51,6 +51,9 @@ module GraphQL
         end
 
         @schema_class = client.types.define_class(self, [ast_node], definition_type)
+
+        # Clear cache only needed during initialization
+        @indexes = nil
       end
 
       # Internal: Get associated owner GraphQL::Client instance.


### PR DESCRIPTION
I believe this is only used during boot (and at that time the cache is useful to avoid some O(N**2) work). This just clears the cache after defining classes in initialize.