### PR TITLE
Define field methods on superclass

### DIFF
--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -232,15 +232,7 @@ module GraphQL
             raise e
           end
 
-          field = type.all_fields.find do |f|
-            f.name == e.name.to_s || ActiveSupport::Inflector.underscore(f.name) == e.name.to_s
-          end
-
-          unless field
-            raise UnimplementedFieldError, "undefined field `#{e.name}' on #{type} type. https://git.io/v1y3m"
-          end
-
-          error_on_defined_field(field.name)
+          raise UnimplementedFieldError, "undefined field `#{e.name}' on #{type} type. https://git.io/v1y3m"
         end
 
         def inspect

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -48,7 +48,7 @@ module GraphQL
 
           klass = Class.new(self)
           klass.const_set :FIELDS, FIELDS_CACHE[field_classes]
-          klass.define_fields(field_classes)
+          klass.define_fields(field_classes.keys)
           klass.instance_variable_set(:@source_definition, definition)
           klass.instance_variable_set(:@_spreads, definition.indexes[:spreads][ast_nodes.first])
 
@@ -85,7 +85,7 @@ module GraphQL
         FIELDS_CACHE = Hash.new { |h, k| h[k] = k }
 
         def define_fields(fields)
-          mod = MODULE_CACHE[fields.keys.sort]
+          mod = MODULE_CACHE[fields.sort]
           include mod
         end
 

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -219,15 +219,7 @@ module GraphQL
             raise UnimplementedFieldError, "undefined field `#{e.name}' on #{type} type. https://git.io/v1y3m"
           end
 
-          if @data.key?(field.name)
-            error_class = ImplicitlyFetchedFieldError
-            message = "implicitly fetched field `#{field.name}' on #{type} type. https://git.io/v1yGL"
-          else
-            error_class = UnfetchedFieldError
-            message = "unfetched field `#{field.name}' on #{type} type. https://git.io/v1y3U"
-          end
-
-          raise error_class, message
+          error_on_defined_field(field.name)
         end
 
         def inspect
@@ -245,6 +237,19 @@ module GraphQL
           buf << " " << ivars.join(" ") if ivars.any?
           buf << ">"
           buf
+        end
+
+        private
+
+        def error_on_defined_field(name)
+          type = self.class.type
+          if @data.key?(name)
+            raise ImplicitlyFetchedFieldError,
+              "implicitly fetched field `#{name}' on #{type} type. https://git.io/v1yGL"
+          else
+            raise UnfetchedFieldError,
+              "unfetched field `#{name}' on #{type} type. https://git.io/v1y3U"
+          end
         end
       end
     end

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -47,6 +47,7 @@ module GraphQL
           end
 
           klass = Class.new(self)
+          klass.const_set :FIELDS, FIELDS_CACHE[field_classes]
           klass.define_fields(field_classes)
           klass.instance_variable_set(:@source_definition, definition)
           klass.instance_variable_set(:@_spreads, definition.indexes[:spreads][ast_nodes.first])
@@ -84,7 +85,6 @@ module GraphQL
         FIELDS_CACHE = Hash.new { |h, k| h[k] = k }
 
         def define_fields(fields)
-          const_set :FIELDS, FIELDS_CACHE[fields]
           mod = MODULE_CACHE[fields.keys.sort]
           include mod
         end

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -270,8 +270,6 @@ class TestQueryResult < MiniTest::Test
     GRAPHQL
 
     response = @client.query(Temp::Query)
-    refute response.data.me.respond_to?(:name)
-    refute response.data.me.respond_to?(:company)
 
     person = Temp::Person.new(response.data.me)
     assert_equal "Josh", person.name
@@ -830,7 +828,6 @@ class TestQueryResult < MiniTest::Test
     repo = Temp::RepositoryFragment.new(response.data.repository)
 
     assert_equal "rails", repo.name
-    refute repo.owner.respond_to?(:login)
 
     owner = Temp::UserFragment.new(repo.owner)
     assert_equal "josh", owner.login
@@ -927,7 +924,6 @@ class TestQueryResult < MiniTest::Test
 
     repo = Temp::RepositoryFragment.new(response.data.repository)
     assert_equal "rails", repo.name
-    refute repo.owner.respond_to?(:login)
 
     owner = Temp::UserFragment.new(repo.owner)
     assert_equal "josh", owner.login


### PR DESCRIPTION
This PR tries to define all accessor methods on the top-level class, instead of defining them on the subclasses. This requires adjusting the methods to check that the method being used _should_ be allowed on this subclass.

This is possible because we can use `type.all_fields` to know the set of methods to use. We do still need to define extra methods on the subclass if aliases are used.

This ends up making error raising for implicit/unfetched fields, since we can raise for them without method missing.

This avoids 130k live allocations in GitHub.