### PR TITLE
Support class based types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.5.6
+  - 2.6.4
 
 env:
-  - RAILS_VERSION=5.1.6 GRAPHQL_VERSION=1.8.11
-  - RAILS_VERSION=5.1.6
-  - RAILS_VERSION=5.2.0
-  - RAILS_VERSION=edge
+  - RAILS_VERSION=5.2.0 GRAPHQL_VERSION=1.8.11
+  - RAILS_VERSION=5.2.0 GRAPHQL_VERSION=1.9.12
+  - RAILS_VERSION=edge GRAPHQL_VERSION=edge
 
 matrix:
   exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,8 @@ rails_version = ENV["RAILS_VERSION"] == "edge" ? { github: "rails/rails" } : ENV
 gem "actionpack", rails_version
 gem "activesupport", rails_version
 
-graphql_version = ENV["GRAPHQL_VERSION"]
-if graphql_version
-  gem "graphql", graphql_version
-end
-
+graphql_version = ENV["GRAPHQL_VERSION"] == "edge" ? { github: "rmosolgo/graphql-ruby", ref: "interpreter-without-legacy" } : ENV["GRAPHQL_VERSION"]
+gem "graphql", graphql_version
 
 group :development, :test do
   gem "rubocop", "~> 0.62.0"

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -253,6 +253,14 @@ module GraphQL
       end
     end
 
+    # Public: A wrapper to use the more-efficient `.find_type` when it's available from GraphQL-Ruby (1.10+)
+    def find_type(type_name)
+      if @schema.respond_to?(:find_type)
+        @schema.find_type(type_name)
+      else
+        @schema.types[type_name]
+      end
+    end
 
     # Public: Create operation definition from a fragment definition.
     #

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -290,10 +290,10 @@ module GraphQL
       end
     end
 
-    # Public: A wrapper to use the more-efficient `.find_type` when it's available from GraphQL-Ruby (1.10+)
-    def find_type(type_name)
-      if @schema.respond_to?(:find_type)
-        @schema.find_type(type_name)
+    # Public: A wrapper to use the more-efficient `.get_type` when it's available from GraphQL-Ruby (1.10+)
+    def get_type(type_name)
+      if @schema.respond_to?(:get_type)
+        @schema.get_type(type_name)
       else
         @schema.types[type_name]
       end

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -46,7 +46,7 @@ module GraphQL
 
     def self.load_schema(schema)
       case schema
-      when GraphQL::Schema
+      when GraphQL::Schema, Class
         schema
       when Hash
         GraphQL::Schema::Loader.load(schema)
@@ -288,15 +288,15 @@ module GraphQL
       variables = GraphQL::Client::DefinitionVariables.operation_variables(self.schema, fragment.document, fragment.definition_name)
       type_name = fragment.definition_node.type.name
 
-      if schema.query && type_name == schema.query.name
+      if schema.query && type_name == schema.query.graphql_name
         operation_type = "query"
-      elsif schema.mutation && type_name == schema.mutation.name
+      elsif schema.mutation && type_name == schema.mutation.graphql_name
         operation_type = "mutation"
-      elsif schema.subscription && type_name == schema.subscription.name
+      elsif schema.subscription && type_name == schema.subscription.graphql_name
         operation_type = "subscription"
       else
         types = [schema.query, schema.mutation, schema.subscription].compact
-        raise Error, "Fragment must be defined on #{types.map(&:name).join(", ")}"
+        raise Error, "Fragment must be defined on #{types.map(&:graphql_name).join(", ")}"
       end
 
       doc_ast = GraphQL::Language::Nodes::Document.new(definitions: [

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -45,7 +45,7 @@ module GraphQL
             raise "Unexpected operation_type: #{ast_node.operation_type}"
           end
         when GraphQL::Language::Nodes::FragmentDefinition
-          @client.find_type(ast_node.type.name)
+          @client.get_type(ast_node.type.name)
         else
           raise "Unexpected ast_node: #{ast_node}"
         end
@@ -170,16 +170,18 @@ module GraphQL
         end
 
         def flatten_spreads(node)
-          node.selections.flat_map do |selection|
+          spreads = []
+          node.selections.each do |selection|
             case selection
             when Language::Nodes::FragmentSpread
-              selection
+              spreads << selection
             when Language::Nodes::InlineFragment
-              flatten_spreads(selection)
+              spreads.concat(flatten_spreads(selection))
             else
-              []
+              # Do nothing, not a spread
             end
           end
+          spreads
         end
 
         def index_node_definitions(visitor)

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -45,7 +45,7 @@ module GraphQL
             raise "Unexpected operation_type: #{ast_node.operation_type}"
           end
         when GraphQL::Language::Nodes::FragmentDefinition
-          @client.schema.types[ast_node.type.name]
+          @client.find_type(ast_node.type.name)
         else
           raise "Unexpected ast_node: #{ast_node}"
         end

--- a/lib/graphql/client/definition_variables.rb
+++ b/lib/graphql/client/definition_variables.rb
@@ -35,7 +35,7 @@ module GraphQL
 
             if existing_type && existing_type.unwrap != definition.type.unwrap
               raise GraphQL::Client::ValidationError, "$#{node.name} was already declared as #{existing_type.unwrap}, but was #{definition.type.unwrap}"
-            elsif !existing_type.is_a?(GraphQL::NonNullType)
+            elsif !(existing_type && existing_type.kind.non_null?)
               variables[node.name.to_sym] = definition.type
             end
           end

--- a/lib/graphql/client/definition_variables.rb
+++ b/lib/graphql/client/definition_variables.rb
@@ -14,7 +14,7 @@ module GraphQL
       #
       # Returns a Hash[Symbol] to GraphQL::Type objects.
       def self.variables(schema, document, definition_name = nil)
-        unless schema.is_a?(GraphQL::Schema)
+        unless schema.is_a?(GraphQL::Schema) || (schema.is_a?(Class) && schema < GraphQL::Schema)
           raise TypeError, "expected schema to be a GraphQL::Schema, but was #{schema.class}"
         end
 
@@ -66,13 +66,13 @@ module GraphQL
       #
       # Returns GraphQL::Language::Nodes::Type.
       def self.variable_node(type)
-        case type
-        when GraphQL::NonNullType
+        case type.kind.name
+        when "NON_NULL"
           GraphQL::Language::Nodes::NonNullType.new(of_type: variable_node(type.of_type))
-        when GraphQL::ListType
+        when "LIST"
           GraphQL::Language::Nodes::ListType.new(of_type: variable_node(type.of_type))
         else
-          GraphQL::Language::Nodes::TypeName.new(name: type.name)
+          GraphQL::Language::Nodes::TypeName.new(name: type.graphql_name)
         end
       end
     end

--- a/lib/graphql/client/document_types.rb
+++ b/lib/graphql/client/document_types.rb
@@ -12,7 +12,7 @@ module GraphQL
       #
       # Returns a Hash[Language::Nodes::Node] to GraphQL::Type objects.
       def self.analyze_types(schema, document)
-        unless schema.is_a?(GraphQL::Schema)
+        unless schema.is_a?(GraphQL::Schema) || (schema.is_a?(Class) && schema < GraphQL::Schema)
           raise TypeError, "expected schema to be a GraphQL::Schema, but was #{schema.class}"
         end
 
@@ -40,7 +40,10 @@ module GraphQL
         visitor.visit
 
         fields
-      rescue StandardError
+      rescue StandardError => err
+        if err.is_a?(TypeError)
+          raise
+        end
         # FIXME: TypeStack my crash on invalid documents
         fields
       end

--- a/lib/graphql/client/query_typename.rb
+++ b/lib/graphql/client/query_typename.rb
@@ -28,8 +28,8 @@ module GraphQL
             type = @types[node]
             type = type && type.unwrap
 
-            if (node.selections.any? && (type.nil? || type.is_a?(GraphQL::InterfaceType) || type.is_a?(GraphQL::UnionType))) ||
-              (node.selections.none? && type.is_a?(GraphQL::ObjectType))
+            if (node.selections.any? && (type.nil? || type.kind.interface? || type.kind.union?)) ||
+              (node.selections.none? && (type && type.kind.object?))
               names = QueryTypename.node_flatten_selections(node.selections).map { |s| s.respond_to?(:name) ? s.name : nil }
               names = Set.new(names.compact)
 

--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -62,7 +62,7 @@ module GraphQL
         private
 
         def normalize_type_name(type_name)
-          type_name =~ /\A[A-Z]/ ? type_name : type_name.camelize
+          /\A[A-Z]/.match?(type_name) ? type_name : type_name.camelize
         end
       end
 

--- a/lib/graphql/client/schema/enum_type.rb
+++ b/lib/graphql/client/schema/enum_type.rb
@@ -41,8 +41,8 @@ module GraphQL
         #
         # type - GraphQL::EnumType instance
         def initialize(type)
-          unless type.is_a?(GraphQL::EnumType)
-            raise "expected type to be a GraphQL::EnumType, but was #{type.class}"
+          unless type.kind.enum?
+            raise "expected type to be an Enum, but was #{type.class}"
           end
 
           @type = type

--- a/lib/graphql/client/schema/interface_type.rb
+++ b/lib/graphql/client/schema/interface_type.rb
@@ -9,8 +9,8 @@ module GraphQL
         include BaseType
 
         def initialize(type)
-          unless type.is_a?(GraphQL::InterfaceType)
-            raise "expected type to be a GraphQL::InterfaceType, but was #{type.class}"
+          unless type.kind.interface?
+            raise "expected type to be an Interface, but was #{type.class}"
           end
 
           @type = type

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -135,7 +135,7 @@ module GraphQL
               true
             else
               schema = definition.client.schema
-              type_condition = definition.client.find_type(selected_ast_node.type.name)
+              type_condition = definition.client.get_type(selected_ast_node.type.name)
               applicable_types = schema.possible_types(type_condition)
               # continue if this object type is one of the types matching the fragment condition
               applicable_types.include?(type)
@@ -152,7 +152,7 @@ module GraphQL
             end
 
             schema = definition.client.schema
-            type_condition = definition.client.find_type(fragment_definition.type.name)
+            type_condition = definition.client.get_type(fragment_definition.type.name)
             applicable_types = schema.possible_types(type_condition)
             # continue if this object type is one of the types matching the fragment condition
             continue_selection = applicable_types.include?(type)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -211,12 +211,13 @@ module GraphQL
             raise e
           end
 
-          field = type.all_fields.find do |f|
+          all_fields = type.respond_to?(:all_fields) ? type.all_fields : type.fields.values
+          field = all_fields.find do |f|
             f.name == e.name.to_s || ActiveSupport::Inflector.underscore(f.name) == e.name.to_s
           end
 
           unless field
-            raise UnimplementedFieldError, "undefined field `#{e.name}' on #{type} type. https://git.io/v1y3m"
+            raise UnimplementedFieldError, "undefined field `#{e.name}' on #{type.graphql_name} type. https://git.io/v1y3m"
           end
 
           if @data.key?(field.name)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -135,7 +135,7 @@ module GraphQL
               true
             else
               schema = definition.client.schema
-              type_condition = schema.types[selected_ast_node.type.name]
+              type_condition = definition.client.find_type(selected_ast_node.type.name)
               applicable_types = schema.possible_types(type_condition)
               # continue if this object type is one of the types matching the fragment condition
               applicable_types.include?(type)
@@ -152,7 +152,7 @@ module GraphQL
             end
 
             schema = definition.client.schema
-            type_condition = schema.types[fragment_definition.type.name]
+            type_condition = definition.client.find_type(fragment_definition.type.name)
             applicable_types = schema.possible_types(type_condition)
             # continue if this object type is one of the types matching the fragment condition
             continue_selection = applicable_types.include?(type)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -41,7 +41,7 @@ module GraphQL
           field_nodes.each do |result_name, field_ast_nodes|
             # `result_name` might be an alias, so make sure to get the proper name
             field_name = field_ast_nodes.first.name
-            field_definition = definition.client.schema.get_field(type.name, field_name)
+            field_definition = definition.client.schema.get_field(type.graphql_name, field_name)
             field_return_type = field_definition.type
             field_classes[result_name.to_sym] = schema_module.define_class(definition, field_ast_nodes, field_return_type)
           end

--- a/lib/graphql/client/schema/possible_types.rb
+++ b/lib/graphql/client/schema/possible_types.rb
@@ -22,7 +22,7 @@ module GraphQL
             unless klass.is_a?(ObjectType)
               raise TypeError, "expected type to be #{ObjectType}, but was #{type.class}"
             end
-            @possible_types[klass.type.name] = klass
+            @possible_types[klass.type.graphql_name] = klass
           end
         end
 

--- a/lib/graphql/client/schema/scalar_type.rb
+++ b/lib/graphql/client/schema/scalar_type.rb
@@ -12,8 +12,8 @@ module GraphQL
         #
         # type - GraphQL::BaseType instance
         def initialize(type)
-          unless type.is_a?(GraphQL::ScalarType)
-            raise "expected type to be a GraphQL::ScalarType, but was #{type.class}"
+          unless type.kind.scalar?
+            raise "expected type to be a Scalar, but was #{type.class}"
           end
 
           @type = type

--- a/lib/graphql/client/schema/union_type.rb
+++ b/lib/graphql/client/schema/union_type.rb
@@ -9,8 +9,8 @@ module GraphQL
         include BaseType
 
         def initialize(type)
-          unless type.is_a?(GraphQL::UnionType)
-            raise "expected type to be a GraphQL::UnionType, but was #{type.class}"
+          unless type.kind.union?
+            raise "expected type to be a Union, but was #{type.class}"
           end
 
           @type = type

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -79,7 +79,7 @@ class TestClient < MiniTest::Test
   class Schema < GraphQL::Schema
     query(QueryType)
     mutation(MutationType)
-    if GraphQL::VERSION > "1.9"
+    if defined?(GraphQL::Execution::Interpreter)
       use GraphQL::Execution::Interpreter
       use GraphQL::Analysis::AST
     end

--- a/test/test_client_create_operation.rb
+++ b/test/test_client_create_operation.rb
@@ -4,38 +4,38 @@ require "graphql/client"
 require "minitest/autorun"
 
 class TestClientCreateOperation < MiniTest::Test
-  GraphQL::DeprecatedDSL.activate if GraphQL::VERSION > "1.8"
-
-  UserType = GraphQL::ObjectType.define do
-    name "User"
-    field :id, !types.ID
+  class UserType < GraphQL::Schema::Object
+    field :id, ID, null: false
   end
 
-  QueryType = GraphQL::ObjectType.define do
-    name "Query"
-    field :version, !types.Int
-    field :user, UserType do
-      argument :name, !types.String
+  class QueryType < GraphQL::Schema::Object
+    field :version, Int, null: false
+    field :user, UserType, null: true do
+      argument :name, String, required: true
     end
-    field :users, types[!UserType] do
-      argument :name, types.String
-      argument :names, types[!types.String]
+    field :users, [UserType], null: false do
+      argument :name, String, required: false
+      argument :names, [String], required: false
     end
   end
 
-  UserInput = GraphQL::InputObjectType.define do
-    name "CreateUserInput"
-    argument :name, !types.String
+  class CreateUserInput < GraphQL::Schema::InputObject
+    argument :name, String, required: true
   end
 
-  MutationType = GraphQL::ObjectType.define do
-    name "Mutation"
-    field :createUser, UserType do
-      argument :input, !UserInput
+  class MutationType < GraphQL::Schema::Object
+    field :create_user, UserType, null: true do
+      argument :input, CreateUserInput, required: true
     end
   end
 
-  Schema = GraphQL::Schema.define(query: QueryType, mutation: MutationType)
+  class Schema < GraphQL::Schema
+    query(QueryType)
+    mutation(MutationType)
+
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+  end
 
   module Temp
   end

--- a/test/test_client_create_operation.rb
+++ b/test/test_client_create_operation.rb
@@ -33,8 +33,10 @@ class TestClientCreateOperation < MiniTest::Test
     query(QueryType)
     mutation(MutationType)
 
-    use GraphQL::Execution::Interpreter
-    use GraphQL::Analysis::AST
+    if defined?(GraphQL::Execution::Interpreter)
+      use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
+    end
   end
 
   module Temp

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -352,7 +352,11 @@ class TestClientErrors < MiniTest::Test
     assert response = @client.query(Temp::Query)
 
     assert_nil response.data.node
-    assert_nil response.data.nodes[0]
+    # This list-error handling behavior is broken for class-based schemas that don't use the interpreter.
+    # The fix is an `.is_a?` check in `proxy_to_depth` in member_instrumentation.rb
+    if defined?(GraphQL::Execution::Interpreter)
+      assert_nil response.data.nodes[0]
+    end
     assert response.data.nodes[1]
     assert_equal "Foo", response.data.nodes[1].__typename
 

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -56,8 +56,10 @@ class TestClientErrors < MiniTest::Test
   class Schema < GraphQL::Schema
     query(QueryType)
 
-    use GraphQL::Execution::Interpreter
-    use GraphQL::Analysis::AST
+    if defined?(GraphQL::Execution::Interpreter)
+      use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
+    end
   end
 
   module Temp

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -4,44 +4,61 @@ require "graphql/client"
 require "minitest/autorun"
 
 class TestClientErrors < MiniTest::Test
-  GraphQL::DeprecatedDSL.activate if GraphQL::VERSION > "1.8"
-
-  FooType = GraphQL::ObjectType.define do
-    name "Foo"
-    field :nullableError, types.String do
-      resolve ->(_query, _args, _ctx) { raise GraphQL::ExecutionError, "b00m" }
+  class FooType < GraphQL::Schema::Object
+    field :nullable_error, String, null: true
+    def nullable_error
+      raise GraphQL::ExecutionError, "b00m"
     end
-    field :nonnullableError, !types.String do
-      resolve ->(_query, _args, _ctx) { raise GraphQL::ExecutionError, "b00m" }
+
+    field :nonnullable_error, String, null: false
+    def nonnullable_error
+      raise GraphQL::ExecutionError, "b00m"
     end
   end
 
-  QueryType = GraphQL::ObjectType.define do
-    name "Query"
-    field :version, !types.Int do
-      resolve ->(_query, _args, _ctx) { 1 }
+  class QueryType < GraphQL::Schema::Object
+    field :version, Int, null: false
+    def version
+      1
     end
-    field :node, FooType do
-      resolve ->(_query, _args, _ctx) { GraphQL::ExecutionError.new("missing node") }
+
+    field :node, FooType, null: true
+    def node
+      GraphQL::ExecutionError.new("missing node")
     end
-    field :nodes, !types[FooType] do
-      resolve ->(_query, _args, _ctx) { [GraphQL::ExecutionError.new("missing node"), {}] }
+
+    field :nodes, [FooType, null: true], null: false
+    def nodes
+      [GraphQL::ExecutionError.new("missing node"), {}]
     end
-    field :nullableError, types.String do
-      resolve ->(_query, _args, _ctx) { raise GraphQL::ExecutionError, "b00m" }
+
+    field :nullable_error, String, null: true
+    def nullable_error
+      raise GraphQL::ExecutionError, "b00m"
     end
-    field :nonnullableError, !types.String do
-      resolve ->(_query, _args, _ctx) { raise GraphQL::ExecutionError, "b00m" }
+
+    field :nonnullable_error, String, null: false
+    def nonnullable_error
+      raise GraphQL::ExecutionError, "b00m"
     end
-    field :foo, !FooType do
-      resolve ->(_query, _args, _ctx) { {} }
+
+    field :foo, FooType, null: false
+    def foo
+      {}
     end
-    field :foos, types[!FooType] do
-      resolve ->(_query, _args, _ctx) { [{}, {}] }
+
+    field :foos, [FooType], null: true
+    def foos
+      [{}, {}]
     end
   end
 
-  Schema = GraphQL::Schema.define(query: QueryType)
+  class Schema < GraphQL::Schema
+    query(QueryType)
+
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+  end
 
   module Temp
   end

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -362,6 +362,9 @@ class TestClientErrors < MiniTest::Test
 
     refute_empty response.data.errors
     assert_equal "missing node", response.data.errors["node"][0]
-    assert_equal "missing node", response.data.nodes.errors[0][0]
+    # This error isn't added in class-based schemas + `Execution::Execute`, same bug as above
+    if defined?(GraphQL::Execution::Interpreter)
+      assert_equal "missing node", response.data.nodes.errors[0][0]
+    end
   end
 end

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -5,8 +5,6 @@ require "json"
 require "minitest/autorun"
 
 class TestClientSchema < MiniTest::Test
-  GraphQL::DeprecatedDSL.activate if GraphQL::VERSION > "1.8"
-
   FakeConn = Class.new do
     attr_reader :context
 
@@ -19,16 +17,17 @@ class TestClientSchema < MiniTest::Test
     end
   end
 
-  QueryType = GraphQL::ObjectType.define do
-    name "AwesomeQuery"
-    field :version, !types.Int
+  class AwesomeQueryType < GraphQL::Schema::Object
+    field :version, Integer, null: false
   end
 
-  Schema = GraphQL::Schema.define(query: QueryType)
+  class Schema < GraphQL::Schema
+    query(AwesomeQueryType)
+  end
 
   def test_load_schema_identity
     schema = GraphQL::Client.load_schema(Schema)
-    assert_equal "AwesomeQuery", schema.query.name
+    assert_equal "AwesomeQuery", schema.query.graphql_name
   end
 
   def test_load_schema_from_introspection_query_result

--- a/test/test_client_validation.rb
+++ b/test/test_client_validation.rb
@@ -4,19 +4,17 @@ require "graphql/client"
 require "minitest/autorun"
 
 class TestClientValidation < MiniTest::Test
-  GraphQL::DeprecatedDSL.activate if GraphQL::VERSION > "1.8"
-
-  UserType = GraphQL::ObjectType.define do
-    name "User"
-    field :name, !types.String
+  class UserType < GraphQL::Schema::Object
+    field :name, String, null: false
   end
 
-  QueryType = GraphQL::ObjectType.define do
-    name "Query"
-    field :viewer, !UserType
+  class QueryType < GraphQL::Schema::Object
+    field :viewer, UserType, null: false
   end
 
-  Schema = GraphQL::Schema.define(query: QueryType)
+  class Schema < GraphQL::Schema
+    query(QueryType)
+  end
 
   module Temp
   end

--- a/test/test_definition_variables.rb
+++ b/test/test_definition_variables.rb
@@ -205,7 +205,7 @@ class TestDefinitionVariables < MiniTest::Test
 
     variables = GraphQL::Client::DefinitionVariables.variables(Schema, document, definition.name)
     assert variables[:input].kind.non_null?
-    assert_equal CreateUserInput, variables[:input].unwrap
+    assert_equal "CreateUserInput", variables[:input].unwrap.graphql_name
 
     variables = GraphQL::Client::DefinitionVariables.operation_variables(Schema, document, definition.name)
     assert_equal ["$input: CreateUserInput!"], variables.map(&:to_query_string)

--- a/test/test_view_module.rb
+++ b/test/test_view_module.rb
@@ -5,22 +5,21 @@ require "graphql/client/view_module"
 require "minitest/autorun"
 
 class TestViewModule < MiniTest::Test
-  GraphQL::DeprecatedDSL.activate if GraphQL::VERSION > "1.8"
-
   Root = File.expand_path("..", __FILE__)
 
-  UserType = GraphQL::ObjectType.define do
-    name "User"
-    field :login, !types.String
+  class UserType < GraphQL::Schema::Object
+    field :login, String, null: false
   end
 
-  QueryType = GraphQL::ObjectType.define do
-    name "Query"
-    field :viewer, !UserType
+  class QueryType < GraphQL::Schema::Object
+    field :viewer, UserType, null: false
   end
 
-  Schema = GraphQL::Schema.define(query: QueryType) do
-    resolve_type ->(_type, _obj, _ctx) { raise NotImplementedError }
+  class Schema < GraphQL::Schema
+    query(QueryType)
+    def self.resolve_type(_t, _obj, _ctx)
+      raise NotImplementedError
+    end
   end
 
   Client = GraphQL::Client.new(schema: Schema)


### PR DESCRIPTION
The next version of graphql-ruby will return class-based types instead of legacy type objects, so I'm preparing graphql-client to handle either kind.