### PR TITLE
Fix for when server returns nil path

### DIFF
--- a/lib/graphql/client/errors.rb
+++ b/lib/graphql/client/errors.rb
@@ -21,7 +21,7 @@ module GraphQL
         errors.each do |error|
           path = ["data"]
           current = data
-          error.fetch("path", []).each do |key|
+          error.fetch("path", []).to_a.each do |key|
             break unless current
             path << key
             current = current[key]

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -78,6 +78,28 @@ class TestClientErrors < MiniTest::Test
     assert_equal expected, actual
 
     actual = {
+      "data" => nil,
+      "errors" => [
+        {
+          "message" => "error",
+          "path" => nil
+        }
+      ]
+    }
+    GraphQL::Client::Errors.normalize_error_paths(actual["data"], actual["errors"])
+    expected = {
+      "data" => nil,
+      "errors" => [
+        {
+          "message" => "error",
+          "path" => nil,
+          "normalizedPath" => %w(data)
+        }
+      ]
+    }
+    assert_equal expected, actual
+
+    actual = {
       "data" => {
         "node" => nil
       },


### PR DESCRIPTION
A server we are accessing is returning path with nil on certain mutation errors. This gem is blowing up when that happens. Here's the stack trace that can be reproduced with the test given.

```
Run options: --seed 15337

# Running:

.......................S....SS...................S.................................................................................................E.................

Finished in 0.495008s, 333.3279 runs/s, 1248.4647 assertions/s.

  1) Error:
TestClientErrors#test_normalize_error_path:
NoMethodError: undefined method `each' for nil:NilClass
    /Users/jgesimondo/code/graphql-client/lib/graphql/client/errors.rb:24:in `block in normalize_error_paths'
    /Users/jgesimondo/code/graphql-client/lib/graphql/client/errors.rb:21:in `each'
    /Users/jgesimondo/code/graphql-client/lib/graphql/client/errors.rb:21:in `normalize_error_paths'
    /Users/jgesimondo/code/graphql-client/test/test_client_errors.rb:89:in `test_normalize_error_path'

165 runs, 618 assertions, 0 failures, 1 errors, 4 skips
```

I've added `.to_a` to fix.