### PR TITLE
Avoid quadratic visits of document trees in DefinitionSlice

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -374,15 +374,15 @@ module GraphQL
       end.to_h
 
       doc.definitions.map do |node|
-        seen = Set.new
-        deps = [node.name]
+        deps = Set.new
         definitions = document_dependencies.definitions.map { |x| [x.name, x] }.to_h
-        deps.each do |name|
-          next if seen.include?(name)
-          seen.add(name)
-          deps.concat dependencies[name]
+
+        queue = [node.name]
+        while name = queue.shift
+          next if deps.include?(name)
+          deps.add(name)
+          queue.concat dependencies[name]
         end
-        deps = Set.new(deps)
 
         definitions = document_dependencies.definitions.select { |x| deps.include?(x.name)  }
         sliced_document = Language::Nodes::Document.new(definitions: definitions)

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -200,18 +200,7 @@ module GraphQL
         raise error
       end
 
-      definitions = {}
-      doc.definitions.each do |node|
-        sliced_document = Language::DefinitionSlice.slice(document_dependencies, node.name)
-        definition = Definition.for(
-          client: self,
-          ast_node: node,
-          document: sliced_document,
-          source_document: doc,
-          source_location: source_location
-        )
-        definitions[node.name] = definition
-      end
+      definitions = sliced_definitions(document_dependencies, doc, source_location: source_location)
 
       name_hook = RenameNodeHook.new(definitions)
       visitor = Language::Visitor.new(document_dependencies)
@@ -378,6 +367,44 @@ module GraphQL
     end
 
     private
+
+    def sliced_definitions(document_dependencies, doc, source_location:)
+      dependencies = document_dependencies.definitions.map do |node|
+        [node.name, find_definition_dependencies(node)]
+      end.to_h
+
+      doc.definitions.map do |node|
+        seen = Set.new
+        deps = [node.name]
+        definitions = document_dependencies.definitions.map { |x| [x.name, x] }.to_h
+        deps.each do |name|
+          next if seen.include?(name)
+          seen.add(name)
+          deps.concat dependencies[name]
+        end
+        deps = Set.new(deps)
+
+        definitions = document_dependencies.definitions.select { |x| deps.include?(x.name)  }
+        sliced_document = Language::Nodes::Document.new(definitions: definitions)
+        definition = Definition.for(
+          client: self,
+          ast_node: node,
+          document: sliced_document,
+          source_document: doc,
+          source_location: source_location
+        )
+
+        [node.name, definition]
+      end.to_h
+    end
+
+    def find_definition_dependencies(node)
+      names = []
+      visitor = Language::Visitor.new(node)
+      visitor[Language::Nodes::FragmentSpread] << -> (node, parent) { names << node.name }
+      visitor.visit
+      names.uniq
+    end
 
     def deep_freeze_json_object(obj)
       case obj


### PR DESCRIPTION
This was some amount more than `O(N**2)` because `find_definition_dependencies` [is recursive and can duplicate work](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/language/definition_slice.rb#L22). In my profiling 8.5% of our app boot was spent in `find_definition_dependencies`.

Previously we would rely on `Language::DefinitionSlice.slice`, and would call it for each definition in the doc. Since these definitions likely refer to each other we end up repeating the work of finding their dependencies. Instead we should visit each tree only once to find its dependencies, and can reuse that for all definitions.

I believe after this change `Definition.for` is still duplicating a lot of work, but that's a much harder problem.