### PR TITLE
Cache type masking; update for 1.10.0.pre1

### DIFF
--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -308,10 +308,12 @@ class TestSchemaType < MiniTest::Test
   def test_transform_lowercase_type_name
     person_type = GraphQL::ObjectType.define do
       name "person"
+      field "f", types.Int
     end
 
     photo_type = GraphQL::ObjectType.define do
       name "photo"
+      field "f", types.Int
     end
 
     search_result_union = GraphQL::UnionType.define do
@@ -339,10 +341,12 @@ class TestSchemaType < MiniTest::Test
   def test_reject_colliding_type_names
     underscored_type = GraphQL::ObjectType.define do
       name "search_result"
+      field "f", types.Int
     end
 
     camelcase_type = GraphQL::ObjectType.define do
       name "SearchResult"
+      field "f", types.Int
     end
 
     query_type = GraphQL::ObjectType.define do


### PR DESCRIPTION
I added an option in GraphQL-Ruby (https://github.com/rmosolgo/graphql-ruby/pull/2363/commits/6874a943779423a349c1495b3398d358eb4a3211) to accept a passed-in instance of `Schema::Warden`. This object remembers _what types are visible_ during a query. Since we're always using a default one, over and over, I think it's safe to share one for all `.parse` calls. The big advantage is that the cache of visible types is reused, instead of calculated over and over. 

