### PR TITLE
Correct error message when providing wrong type of query

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -362,7 +362,7 @@ module GraphQL
       raise NotImplementedError, "client network execution not configured" unless execute
 
       unless definition.is_a?(OperationDefinition)
-        raise TypeError, "expected definition to be a #{OperationDefinition.name} but was #{document.class.name}"
+        raise TypeError, "expected definition to be a #{OperationDefinition.name} but was #{definition.class.name}"
       end
 
       if allow_dynamic_queries == false && definition.name.nil?


### PR DESCRIPTION
`GraphQL::Client` is raising a `TypeError` when `definition` isn't a `OperationDefinition`.
However, error message was using a `definition.class.name` as info what was provided - which was always equal to `GraphQL::Language::Nodes::Document`.

This commit fixes that and outputs real type of query provided in the error message.