### PR TITLE
Improve docs "copypastability"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module SWAPI
   HTTP = GraphQL::Client::HTTP.new("https://example.com/graphql") do
     def headers(context)
       # Optionally set any HTTP headers
-      { "User-Agent": "My Client" }
+      { "User-Agent" => "My Client" }
     end
   end  
 

--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -22,7 +22,7 @@ module GraphQL
       #
       #   GraphQL::Client::HTTP.new("http://graphql-swapi.parseapp.com/") do
       #     def headers(context)
-      #       { "User-Agent": "My Client" }
+      #       { "User-Agent" => "My Client" }
       #     end
       #   end
       #


### PR DESCRIPTION
Hey there, not sure if it is an issue with whatever http / ruby version we're using but I noticed that my user agent is not properly set as a header if I use symbols, I end up with `Ruby,<CUSTOM_AGENT>` when my requests reach other apps.

It took me a while to figure this one out so better save other devs times too :smile: 