### PR TITLE
Allow non capitalized query names

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -227,7 +227,8 @@ module GraphQL
       else
         Module.new do
           definitions.each do |name, definition|
-            const_set(name, definition)
+            module_name = name.sub(/\S/, &:upcase)
+            const_set(module_name, definition)
           end
         end
       end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -199,6 +199,36 @@ class TestClient < MiniTest::Test
     assert_equal(query_string, Temp::UserDocument::GetUser.document.to_query_string)
   end
 
+  def test_client_parse_query_document_non_capitalized_query_name
+    Temp.const_set :UserDocument, @client.parse(<<-'GRAPHQL')
+      query getUser {
+        viewer {
+          id
+        }
+      }
+    GRAPHQL
+
+    assert_kind_of GraphQL::Client::OperationDefinition, Temp::UserDocument::GetUser
+    assert_equal "TestClient::Temp::UserDocument", Temp::UserDocument.name
+    assert_equal "TestClient::Temp::UserDocument::GetUser", Temp::UserDocument::GetUser.name
+    assert_equal "TestClient__Temp__UserDocument__GetUser", Temp::UserDocument::GetUser.definition_name
+
+    assert_kind_of GraphQL::Language::Nodes::OperationDefinition, Temp::UserDocument::GetUser.definition_node
+    assert_equal "TestClient__Temp__UserDocument__GetUser", Temp::UserDocument::GetUser.definition_node.name
+    assert_equal "query", Temp::UserDocument::GetUser.definition_node.operation_type
+
+    query_string = <<-'GRAPHQL'.gsub(/^      /, "").chomp
+      query TestClient__Temp__UserDocument__GetUser {
+        viewer {
+          id
+        }
+      }
+    GRAPHQL
+
+    assert_equal(query_string, @client.document.to_query_string)
+    assert_equal(query_string, Temp::UserDocument::GetUser.document.to_query_string)
+  end
+
   def test_client_parse_anonymous_mutation
     Temp.const_set :StarMutation, @client.parse(<<-'GRAPHQL')
       mutation {

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -308,10 +308,12 @@ class TestSchemaType < MiniTest::Test
   def test_transform_lowercase_type_name
     person_type = GraphQL::ObjectType.define do
       name "person"
+      field :name, !types.String
     end
 
     photo_type = GraphQL::ObjectType.define do
       name "photo"
+      field :name, !types.String
     end
 
     search_result_union = GraphQL::UnionType.define do
@@ -339,10 +341,12 @@ class TestSchemaType < MiniTest::Test
   def test_reject_colliding_type_names
     underscored_type = GraphQL::ObjectType.define do
       name "search_result"
+      field :value, !types.String
     end
 
     camelcase_type = GraphQL::ObjectType.define do
       name "SearchResult"
+      field :value, !types.String
     end
 
     query_type = GraphQL::ObjectType.define do


### PR DESCRIPTION
Because `const_set` does't  allow constants with lower case this was preventing from defining queries like:

```
       query getUser {
        viewer {
          id
        }
      }
```