### PR TITLE
Add option to preserve doc name when parsing query

### DIFF
--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -25,7 +25,14 @@ module GraphQL
         end
       end
 
-      def initialize(client:, document:, source_document:, ast_node:, source_location:)
+      def initialize(
+        client:,
+        document:,
+        source_document:,
+        ast_node:,
+        source_location:,
+        preserve_node_name: false
+      )
         @client = client
         @document = document
         @source_document = source_document
@@ -54,6 +61,10 @@ module GraphQL
 
         # Clear cache only needed during initialization
         @indexes = nil
+
+        if preserve_node_name && ast_node.name != "__anonymous__"
+          @definition_name = ast_node.name
+        end
       end
 
       # Internal: Get associated owner GraphQL::Client instance.

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -308,10 +308,12 @@ class TestSchemaType < MiniTest::Test
   def test_transform_lowercase_type_name
     person_type = GraphQL::ObjectType.define do
       name "person"
+      field :first_name, GraphQL::STRING_TYPE
     end
 
     photo_type = GraphQL::ObjectType.define do
       name "photo"
+      field :name, GraphQL::STRING_TYPE
     end
 
     search_result_union = GraphQL::UnionType.define do
@@ -355,7 +357,7 @@ class TestSchemaType < MiniTest::Test
       resolve_type ->(_type, _obj, _ctx) { raise NotImplementedError }
     end
 
-    assert_raises ArgumentError do
+    assert_raises GraphQL::Schema::InvalidTypeError do
       GraphQL::Client::Schema.generate(schema)
     end
   end


### PR DESCRIPTION
Currently, if a given operation contains an operation name, graphql-client will rename the operation to the assigned constant's name. It would be useful to override this option to preserve the name that is defined.

This came up on my team because we use a separate manager service for registering and tracking operations. It is nice to have these queries in a file that get uploaded to the manager _and_ read by the ruby service, and having the renaming of the operation hidden in code makes it somewhat weird to keep track of them.