### PR TITLE
print error response message from server if present

### DIFF
--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -75,7 +75,11 @@ module GraphQL
         when Net::HTTPOK, Net::HTTPBadRequest
           JSON.parse(response.body)
         else
-          { "errors" => [{ "message" => "#{response.code} #{response.message}" }] }
+          if response.body.nil?
+            { "errors" => [{ "message" => "#{response.code} #{response.message}" }] }
+          else
+            JSON.parse(response.body)
+          end
         end
       end
 


### PR DESCRIPTION
A graphql service was returning '500 Internal Server Error', thats what graphql-client kept printing, on debugging further I figured that they were sending the actual reason in the response body.
 
Hope this patch helps people integrating GraphQL services save couple of hours in debugging.