### PR TITLE
Use safe_constantize instead of rescuing

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -135,11 +135,7 @@ module GraphQL
           # which corresponds to the spread.
           # We depend on ActiveSupport to either find the already-loaded
           # constant, or to load the constant by name
-          begin
-            fragment = ActiveSupport::Inflector.constantize(const_name)
-          rescue NameError
-            fragment = nil
-          end
+          fragment = ActiveSupport::Inflector.safe_constantize(const_name)
 
           case fragment
           when FragmentDefinition


### PR DESCRIPTION
The rescue that was here previously can be over-eager in capturing exceptions, and could mask error that weren't specifically that `const_name` didn't exist but could be any `NameError` that happened eager loading that class or that class's dependencies.

For this reason `ActiveSupport` provides `safe_constantize` which returns `nil` only if the `NameError` comes from the constant we are requesting, and raises the exception otherwise.