### PR TITLE
Fix schema not found

### DIFF
--- a/lib/graphql/client/error.rb
+++ b/lib/graphql/client/error.rb
@@ -8,6 +8,10 @@ module GraphQL
     class InvariantError < Error
     end
 
+    # The Server has returned an error while executing a query
+    class QueryError < Error
+    end
+
     class ImplicitlyFetchedFieldError < NoMethodError
     end
 

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -33,13 +33,13 @@ class TestClientSchema < MiniTest::Test
   def test_load_schema_from_introspection_query_result
     result = Schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
     schema = GraphQL::Client.load_schema(result)
-    assert_equal "AwesomeQuery", schema.query.name
+    assert_equal "AwesomeQuery", schema.query.graphql_name
   end
 
   def test_load_schema_from_json_string
     json = JSON.generate(Schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY))
     schema = GraphQL::Client.load_schema(json)
-    assert_equal "AwesomeQuery", schema.query.name
+    assert_equal "AwesomeQuery", schema.query.graphql_name
   end
 
   def test_load_schema_ignores_missing_path

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -46,6 +46,29 @@ class TestClientSchema < MiniTest::Test
     refute GraphQL::Client.load_schema("#{__dir__}/missing-schema.json")
   end
 
+  def test_dump_schema_when_execute_has_not_found_error
+    executor = Class.new do
+      def execute(_)
+        {"errors"=>[{"message"=>"404 Not Found"}]}
+      end
+    end.new
+    error = assert_raises(GraphQL::Client::QueryError) {GraphQL::Client.dump_schema(executor)}
+    assert_equal "The query returned an error (404 Not Found)", error.message
+  end
+
+  def test_dump_schema_when_execute_has_several_errors
+    executor = Class.new do
+      def execute(_)
+        {"errors"=>[
+          {"message" => "error 1"},
+          {"message" => "error 2"}]
+        }
+      end
+    end.new
+    error = assert_raises(GraphQL::Client::QueryError) {GraphQL::Client.dump_schema(executor)}
+    assert_equal "The query returned an error (error 1; error 2)", error.message
+  end
+
   def test_dump_schema
     schema = GraphQL::Client.dump_schema(Schema)
     assert_kind_of Hash, schema

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -308,10 +308,12 @@ class TestSchemaType < MiniTest::Test
   def test_transform_lowercase_type_name
     person_type = GraphQL::ObjectType.define do
       name "person"
+      field :name, types.String
     end
 
     photo_type = GraphQL::ObjectType.define do
       name "photo"
+      field :name, types.String
     end
 
     search_result_union = GraphQL::UnionType.define do
@@ -339,10 +341,12 @@ class TestSchemaType < MiniTest::Test
   def test_reject_colliding_type_names
     underscored_type = GraphQL::ObjectType.define do
       name "search_result"
+      field :id, types.ID
     end
 
     camelcase_type = GraphQL::ObjectType.define do
       name "SearchResult"
+      field :id, types.ID
     end
 
     query_type = GraphQL::ObjectType.define do


### PR DESCRIPTION
Hi,
When the introcspection endpoint returns a 404 the GraphQL::Client#dump_schema raises a KeyError. 

This pull request reuses the error-handling from GraphQL::Client#query in dump_schema to properly handle errors. If an error is detected dump_schema raises a QueryError now.

I also fixed some tests first as they seemed broken?

Regards
Jorg