### PR TITLE
Use objects instead of classes to represent "defined" types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - ./lib/rubocop/cop/graphql/heredoc
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.7
 
 GraphQL/Heredoc:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ graphql_version = ENV["GRAPHQL_VERSION"] == "edge" ? { github: "rmosolgo/graphql
 gem "graphql", graphql_version
 
 group :development, :test do
-  gem "rubocop", "~> 0.62.0"
+  gem "rubocop", "~> 0.82.0"
 end

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -115,9 +115,18 @@ module GraphQL
           else
             cast_object(obj)
           end
+        when GraphQL::Client::Schema::ObjectType::WithDefinition
+          case obj
+          when nil, schema_class.klass
+            obj
+          when Hash
+            schema_class.new(obj, errors)
+          else
+            cast_object(obj)
+          end
         when GraphQL::Client::Schema::ObjectType
           case obj
-          when NilClass, schema_class
+          when nil, schema_class
             obj
           when Hash
             schema_class.new(obj, errors)

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -144,8 +144,8 @@ module GraphQL
 
         def cast_object(obj)
           if obj.class.is_a?(GraphQL::Client::Schema::ObjectType)
-            unless obj.class._spreads.include?(definition_node.name)
-              raise TypeError, "#{definition_node.name} is not included in #{obj.class.source_definition.name}"
+            unless obj._spreads.include?(definition_node.name)
+              raise TypeError, "#{definition_node.name} is not included in #{obj.source_definition.name}"
             end
             schema_class.cast(obj.to_h, obj.errors)
           else

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -117,8 +117,14 @@ module GraphQL
           end
         when GraphQL::Client::Schema::ObjectType::WithDefinition
           case obj
-          when nil, schema_class.klass
-            obj
+          when schema_class.klass
+            if obj.definer == schema_class
+              obj
+            else
+              cast_object(obj)
+            end
+          when nil
+            nil
           when Hash
             schema_class.new(obj, errors)
           else

--- a/lib/graphql/client/definition.rb
+++ b/lib/graphql/client/definition.rb
@@ -118,7 +118,7 @@ module GraphQL
         when GraphQL::Client::Schema::ObjectType::WithDefinition
           case obj
           when schema_class.klass
-            if obj.definer == schema_class
+            if obj._definer == schema_class
               obj
             else
               cast_object(obj)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -40,8 +40,6 @@ module GraphQL
           end
 
           def method_missing(name, *args)
-            attr = READERS[name]
-            type = @definer.defined_fields[attr]
             if (attr = READERS[name]) && (type = @definer.defined_fields[attr])
               @casted_data.fetch(attr) do
                 @casted_data[attr] = type.cast(@data[attr], @errors.filter_by_path(attr))

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -89,7 +89,9 @@ module GraphQL
           include BaseType
           include ObjectType
 
-          attr_reader :klass, :defined_fields, :definition, :spreads
+          EMPTY_SET = Set.new.freeze
+
+          attr_reader :klass, :defined_fields, :definition
 
           def type
             @klass.type
@@ -99,11 +101,19 @@ module GraphQL
             @klass.fields
           end
 
+          def spreads
+            if defined?(@spreads)
+              @spreads
+            else
+              EMPTY_SET
+            end
+          end
+
           def initialize(klass, defined_fields, definition, spreads)
             @klass = klass
             @defined_fields = defined_fields.transform_keys { |key| -key.to_s }
             @definition = definition
-            @spreads = spreads
+            @spreads = spreads unless spreads.empty?
 
             @defined_fields.keys.each do |attr|
               name = ActiveSupport::Inflector.underscore(attr)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -60,6 +60,17 @@ module GraphQL
             end
           end
 
+          # It's possible to define "errors" as a field. Ideally this shouldn't
+          # happen, but if it does we should prefer the field rather than the
+          # builtin error type.
+          def errors
+            if type = @definer.defined_fields["errors"]
+              read_attribute("errors", type)
+            else
+              super()
+            end
+          end
+
           private
 
           def verify_collocated_path

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -64,12 +64,12 @@ module GraphQL
             @klass = klass
             @type = type
             @fields = fields
-            @defined_fields = defined_fields.transform_keys(&:to_s)
+            @defined_fields = defined_fields.transform_keys { |key| -key.to_s }
             @definition = definition
             @spreads = spreads
 
             @defined_methods = @defined_fields.keys.map do |attr|
-              [ActiveSupport::Inflector.underscore(attr).to_sym, attr.to_s]
+              [ActiveSupport::Inflector.underscore(attr).to_sym, -attr.to_s]
             end.to_h
             @defined_predicates = @defined_methods.transform_keys do |name|
               :"#{name}?"

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -24,6 +24,8 @@ module GraphQL
         end
 
         module Defined
+          attr_reader :definer
+
           def initialize(data = {}, errors = Errors.new, definer)
             super(data, errors)
             @definer = definer
@@ -59,7 +61,7 @@ module GraphQL
           include BaseType
           include ObjectType
 
-          attr_reader :defined_fields, :definition, :spreads
+          attr_reader :klass, :defined_fields, :definition, :spreads
 
           def type
             @klass.type

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -239,13 +239,6 @@ module GraphQL
       end
 
       class ObjectClass
-        module ClassMethods
-          attr_reader :source_definition
-          attr_reader :_spreads
-        end
-
-        extend ClassMethods
-
         def initialize(data = {}, errors = Errors.new)
           @data = data
           @casted_data = {}

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -46,9 +46,7 @@ module GraphQL
                 read_attribute(attr, type)
               end
             elsif (attr = PREDICATES[name]) && @definer.defined_fields[attr]
-              verify_collocated_path do
-                has_attribute?(attr)
-              end
+              has_attribute?(attr)
             else
               super
             end

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -52,6 +52,14 @@ module GraphQL
             end
           end
 
+          def respond_to_missing?(name, priv)
+            if (attr = READERS[name]) || (attr = PREDICATES[name])
+              @definer.defined_fields.key?(attr) || super
+            else
+              super
+            end
+          end
+
           private
 
           def verify_collocated_path

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -112,7 +112,9 @@ module GraphQL
 
           def initialize(klass, defined_fields, definition, spreads)
             @klass = klass
-            @defined_fields = defined_fields.transform_keys { |key| -key.to_s }
+            @defined_fields = defined_fields.map do |k, v|
+              [-k.to_s, v]
+            end.to_h
             @definition = definition
             @spreads = spreads unless spreads.empty?
 

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -59,15 +59,18 @@ module GraphQL
           include BaseType
           include ObjectType
 
-          attr_reader :type, :fields
           attr_reader :defined_fields, :definition, :spreads
 
-          attr_reader :defined_methods, :defined_predicates
+          def type
+            @klass.type
+          end
 
-          def initialize(klass, type, fields, defined_fields, definition, spreads)
+          def fields
+            @klass.fields
+          end
+
+          def initialize(klass, defined_fields, definition, spreads)
             @klass = klass
-            @type = type
-            @fields = fields
             @defined_fields = defined_fields.transform_keys { |key| -key.to_s }
             @definition = definition
             @spreads = spreads
@@ -113,7 +116,7 @@ module GraphQL
 
           spreads = definition.indexes[:spreads][ast_nodes.first]
 
-          WithDefinition.new(defined_class, type, fields, field_classes, definition, spreads)
+          WithDefinition.new(defined_class, field_classes, definition, spreads)
         end
 
         def define_field(name, type)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -19,6 +19,7 @@ module GraphQL
 
             defined_class = Class.new(self)
             defined_class.prepend Defined
+            const_set(:DefinedClass, defined_class)
             define_singleton_method(:defined_class) { defined_class }
           end
         end

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -17,10 +17,11 @@ module GraphQL
             define_singleton_method(:type) { type }
             define_singleton_method(:fields) { fields }
 
+            const_set(:READERS, {})
+            const_set(:PREDICATES, {})
+
             defined_class = Class.new(self)
             defined_class.prepend Defined
-            defined_class.const_set(:READERS, {})
-            defined_class.const_set(:PREDICATES, {})
             const_set(:DefinedClass, defined_class)
             define_singleton_method(:defined_class) { defined_class }
           end

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -24,6 +24,9 @@ module GraphQL
             defined_class.prepend Defined
             const_set(:DefinedClass, defined_class)
             define_singleton_method(:defined_class) { defined_class }
+
+            object_base_class = self
+            define_singleton_method(:object_base_class) { object_base_class }
           end
         end
 
@@ -306,7 +309,7 @@ module GraphQL
         end
 
         def inspect
-          parent = self.class.ancestors.reverse.find { |m| m.is_a?(ObjectType) }
+          parent = self.class.object_base_class
 
           ivars = @data.map { |key, value|
             if value.is_a?(Hash) || value.is_a?(Array)

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -20,8 +20,8 @@ module GraphQL
             const_set(:READERS, {})
             const_set(:PREDICATES, {})
 
-            defined_class = Class.new(self)
-            defined_class.prepend Defined
+            defined_class = self
+            prepend Defined
             const_set(:DefinedClass, defined_class)
             define_singleton_method(:defined_class) { defined_class }
 
@@ -33,8 +33,12 @@ module GraphQL
         module Defined
           attr_reader :definer
 
-          def initialize(data, errors, definer)
+          def initialize(data = {}, errors = Errors.new, definer = nil)
             super(data, errors)
+
+            # If we are not provided a definition, we can use this empty default
+            definer ||= WithDefinition.new(self.class.object_base_class, {}, nil, [])
+
             @definer = definer
           end
 

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -24,8 +24,6 @@ module GraphQL
         end
 
         module Defined
-          attr_reader :definer
-
           def initialize(data = {}, errors = Errors.new, definer = nil)
             super(data, errors)
 
@@ -33,6 +31,10 @@ module GraphQL
             definer ||= WithDefinition.new(self.class, {}, nil, [])
 
             @definer = definer
+          end
+
+          def _definer
+            @definer
           end
 
           def _spreads

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -30,7 +30,7 @@ module GraphQL
         module Defined
           attr_reader :definer
 
-          def initialize(data = {}, errors = Errors.new, definer)
+          def initialize(data, errors, definer)
             super(data, errors)
             @definer = definer
           end

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -306,7 +306,7 @@ module GraphQL
         end
 
         def inspect
-          parent = self.class.ancestors.select { |m| m.is_a?(ObjectType) }.last
+          parent = self.class.ancestors.reverse.find { |m| m.is_a?(ObjectType) }
 
           ivars = @data.map { |key, value|
             if value.is_a?(Hash) || value.is_a?(Array)

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -855,6 +855,27 @@ class TestQueryResult < MiniTest::Test
     assert_equal "secret", user.password
   end
 
+  def test_parse_fragment_with_field_named_error
+    Temp.const_set :UserFragment, @client.parse(<<-'GRAPHQL')
+      fragment on User {
+        errors: profileName
+      }
+    GRAPHQL
+
+    Temp.const_set :Query, @client.parse(<<-'GRAPHQL')
+      {
+        node(id: "1") {
+          ...TestQueryResult::Temp::UserFragment
+        }
+      }
+    GRAPHQL
+
+    response = @client.query(Temp::Query)
+    user = Temp::UserFragment.new(response.data.node)
+
+    assert_equal "Josh", user.errors
+  end
+
   def test_parse_fragment_query_result_aliases
     Temp.const_set :UserFragment, @client.parse(<<-'GRAPHQL')
       fragment on User {

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -256,6 +256,8 @@ class TestQueryResult < MiniTest::Test
     refute response.data.me.respond_to?(:company)
 
     person = Temp::Person.new(response.data.me)
+    assert person.respond_to?(:name)
+    assert person.respond_to?(:company)
     assert_equal "Josh", person.name
     assert_equal "GitHub", person.company
   end
@@ -812,9 +814,11 @@ class TestQueryResult < MiniTest::Test
     repo = Temp::RepositoryFragment.new(response.data.repository)
 
     assert_equal "rails", repo.name
+    assert repo.respond_to?(:name)
     refute repo.owner.respond_to?(:login)
 
     owner = Temp::UserFragment.new(repo.owner)
+    assert owner.respond_to?(:login)
     assert_equal "josh", owner.login
   end
 
@@ -909,12 +913,15 @@ class TestQueryResult < MiniTest::Test
 
     repo = Temp::RepositoryFragment.new(response.data.repository)
     assert_equal "rails", repo.name
+    assert repo.respond_to?(:name)
     refute repo.owner.respond_to?(:login)
 
     owner = Temp::UserFragment.new(repo.owner)
+    assert owner.respond_to?(:login)
     assert_equal "josh", owner.login
 
     owner = Temp::UserFragment.new(owner)
+    assert owner.respond_to?(:login)
     assert_equal "josh", owner.login
   end
 


### PR DESCRIPTION
Replacing #213

This attempts to improve the memory usage of object type definitions in applications with a large number of queries. This is done by having `define_class` return a plain object instead of a dynamic subclass.

The behaviour is a bit confusing here because we are building a GraphQL type system on top of Ruby's type system, which results in a pretty complex inheritance chain. To summarize:
* `ObjectType.new` returns a new class: a subclass of `ObjectClass` which is tied to a graphql type. This is an "ObjectType". This class is never in practice instantiated since it has no fields (other than in tests). These are usually assigned to a constant and so have a `name`.
* `ObjectType#define_class` makes another subclass from that object type and ties it to how this type is used in a query: the query definition, the fields being included, their types (this ends up recursive), etc. These have methods defined for every field they include. A new class is created here each time a type is referenced in a query. These are usually anonymous classes.
* `new` is called on those "defined classes", to build these `ObjectClass` instances.

This PR changes how this works.

* The "ObjectType"s, returned by `ObjectType.new`, can now be instantiated, but expect to be passed information about the definiton: fields defined on it, types, spreads, etc.
* `ObjectType#define_class` now returns a new `WithDefinition` instance. This is a plain Ruby object, instead of a subclass. It implements `#new` which will make an ObjectClass with the correct information from this definition.

This is made possible by removing the method definitions for fields, and instead relying on `method_missing` every time a field is accessed.