### PR TITLE
Add methods for dumping/loading schema SDL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 pkg
+tmp

--- a/README.md
+++ b/README.md
@@ -34,12 +34,20 @@ module SWAPI
   # Fetch latest schema on init, this will make a network request
   Schema = GraphQL::Client.load_schema(HTTP)
 
-  # However, it's smart to dump this to a JSON file and load from disk
+  # However, it's smart to dump this to a JSON or SDL file and load from disk
   #
   # Run it from a script or rake task
   #   GraphQL::Client.dump_schema(SWAPI::HTTP, "path/to/schema.json")
   #
+  #   or
+  #
+  #   GraphQL::Client.dump_schema_definition(SWAPI::HTTP, "path/to/schema.graphql")
+  #
   # Schema = GraphQL::Client.load_schema("path/to/schema.json")
+  #
+  #   or 
+  #
+  # Schema = GraphQL::Client.load_schema_from_definition("path/to/schema.graphql")
 
   Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
 end

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -67,6 +67,10 @@ module GraphQL
       end
     end
 
+    def self.load_schema_from_definition(schema)
+      GraphQL::Schema.from_definition(schema)
+    end
+
     IntrospectionDocument = GraphQL.parse(GraphQL::Introspection::INTROSPECTION_QUERY)
 
     def self.dump_schema(schema, io = nil, context: {})
@@ -84,6 +88,20 @@ module GraphQL
       if io
         io = File.open(io, "w") if io.is_a?(String)
         io.write(JSON.pretty_generate(result))
+        io.close_write
+      end
+
+      result
+    end
+
+    def self.dump_schema_definition(schema, io = nil, context: {})
+      introspection_results = dump_schema(schema, context: context)
+      introspected_schema = GraphQL::Schema.from_introspection(introspection_results)
+      result = introspected_schema.to_definition
+
+      if io
+        io = File.open(io, "w") if io.is_a?(String)
+        io.write(result)
         io.close_write
       end
 


### PR DESCRIPTION
Schema dumps in SDL tend to be easier for humans to read so this PR adds methods to `GraphQL::Client` for dumping/loading schema SDL. I chose to add new methods to avoid a breaking API change but modifying the behavior of the existing dump/load methods is another option if we think this is the preferred default behavior.