### PR TITLE
Raise an exception if introspection queries fail

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -81,6 +81,10 @@ module GraphQL
         context: context
       ).to_h
 
+      if result["errors"] && !result["errors"].empty?
+        raise "Introspection query failed: #{JSON.pretty_generate(result['errors'])}"
+      end
+
       if io
         io = File.open(io, "w") if io.is_a?(String)
         io.write(JSON.pretty_generate(result))

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -17,6 +17,12 @@ class TestClientSchema < MiniTest::Test
     end
   end
 
+  ErrorConn = Class.new do
+    def execute(document:, operation_name: nil, variables: {}, context: {})
+      { "errors" => [{ "message" => "something bad happened" }] }
+    end
+  end
+
   class AwesomeQueryType < GraphQL::Schema::Object
     field :version, Integer, null: false
   end
@@ -63,5 +69,12 @@ class TestClientSchema < MiniTest::Test
     conn = FakeConn.new
     GraphQL::Client.dump_schema(conn, StringIO.new, context: { user_id: 1})
     assert_equal({ user_id: 1 }, conn.context)
+  end
+
+  def test_dump_schema_errors
+    conn = ErrorConn.new
+    assert_raises StandardError do
+      GraphQL::Client.dump_schema(conn)
+    end
   end
 end


### PR DESCRIPTION
`GraphQL::Client.dump_schema` doesn't detect failed introspection queries which can result in corrupt schema dumps. This PR changes the method to fail loudly if there is a problem running the introspection query.