### PR TITLE
Raise QueryError instead of KeyError in GraphQL::Client#dump_schema 

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -74,12 +74,20 @@ module GraphQL
         raise TypeError, "expected schema to respond to #execute(), but was #{schema.class}"
       end
 
-      result = schema.execute(
+      payload = {
         document: IntrospectionDocument,
         operation_name: "IntrospectionQuery",
         variables: {},
         context: context
-      ).to_h
+      }
+
+      result = schema.execute(payload).to_h
+
+      _, errors, __ = eval_query_result(payload, result)
+      if errors.any?
+        errors_detail = errors.map { |e| e["message"] }.join("; ")
+        raise QueryError, "The query returned an error (#{errors_detail})"
+      end
 
       if io
         io = File.open(io, "w") if io.is_a?(String)
@@ -341,18 +349,7 @@ module GraphQL
         )
       end
 
-      deep_freeze_json_object(result)
-
-      data, errors, extensions = result.values_at("data", "errors", "extensions")
-
-      errors ||= []
-      errors = errors.map(&:dup)
-      GraphQL::Client::Errors.normalize_error_paths(data, errors)
-
-      errors.each do |error|
-        error_payload = payload.merge(message: error["message"], error: error)
-        ActiveSupport::Notifications.instrument("error.graphql", error_payload)
-      end
+      data, errors, extensions = self.class.eval_query_result(payload, result)
 
       Response.new(
         result,
@@ -412,7 +409,23 @@ module GraphQL
       names.uniq
     end
 
-    def deep_freeze_json_object(obj)
+    def self.eval_query_result(payload, result)
+      deep_freeze_json_object(result)
+
+      data, errors, extensions = result.values_at("data", "errors", "extensions")
+
+      errors ||= []
+      errors = errors.map(&:dup)
+      GraphQL::Client::Errors.normalize_error_paths(data, errors)
+
+      errors.each do |error|
+        error_payload = payload.merge(message: error["message"], error: error)
+        ActiveSupport::Notifications.instrument("error.graphql", error_payload)
+      end
+      [data, errors, extensions]
+    end
+
+    def self.deep_freeze_json_object(obj)
       case obj
       when String
         obj.freeze

--- a/lib/graphql/client/error.rb
+++ b/lib/graphql/client/error.rb
@@ -8,6 +8,10 @@ module GraphQL
     class InvariantError < Error
     end
 
+    # The Server has returned an error while executing a query
+    class QueryError < Error
+    end
+
     class ImplicitlyFetchedFieldError < NoMethodError
     end
 

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -46,6 +46,29 @@ class TestClientSchema < MiniTest::Test
     refute GraphQL::Client.load_schema("#{__dir__}/missing-schema.json")
   end
 
+  def test_dump_schema_when_execute_has_not_found_error
+    executor = Class.new do
+      def execute(_)
+        {"errors"=>[{"message"=>"404 Not Found"}]}
+      end
+    end.new
+    error = assert_raises(GraphQL::Client::QueryError) {GraphQL::Client.dump_schema(executor)}
+    assert_equal "The query returned an error (404 Not Found)", error.message
+  end
+
+  def test_dump_schema_when_execute_has_several_errors
+    executor = Class.new do
+      def execute(_)
+        {"errors"=>[
+          {"message" => "error 1"},
+          {"message" => "error 2"}]
+        }
+      end
+    end.new
+    error = assert_raises(GraphQL::Client::QueryError) {GraphQL::Client.dump_schema(executor)}
+    assert_equal "The query returned an error (error 1; error 2)", error.message
+  end
+
   def test_dump_schema
     schema = GraphQL::Client.dump_schema(Schema)
     assert_kind_of Hash, schema


### PR DESCRIPTION
Hi,
When the introcspection endpoint returns a 404 GraphQL::Client#dump_schema raises a KeyError.

This pull request reuses the error-handling from GraphQL::Client#query in dump_schema to properly handle errors. If an error is detected dump_schema raises a QueryError now.

Could you please merge that into master?

Regards
Jorg