### PR TITLE
Use a cache of Schema.possible_types

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -97,8 +97,29 @@ module GraphQL
       @document_tracking_enabled = false
       @allow_dynamic_queries = false
       @enforce_collocated_callers = enforce_collocated_callers
-
+      if schema.is_a?(Class)
+        @possible_types = schema.possible_types
+      end
       @types = Schema.generate(@schema)
+    end
+
+    # A cache of the schema's merged possible types
+    # @param type_condition [Class, String] a type definition or type name
+    def possible_types(type_condition = nil)
+      if type_condition
+        if defined?(@possible_types)
+          if type_condition.respond_to?(:graphql_name)
+            type_condition = type_condition.graphql_name
+          end
+          @possible_types[type_condition]
+        else
+          @schema.possible_types(type_condition)
+        end
+      elsif defined?(@possible_types)
+        @possible_types
+      else
+        @schema.possible_types(type_condition)
+      end
     end
 
     def parse(str, filename = nil, lineno = nil)

--- a/lib/graphql/client/schema/interface_type.rb
+++ b/lib/graphql/client/schema/interface_type.rb
@@ -21,7 +21,7 @@ module GraphQL
         end
 
         def define_class(definition, ast_nodes)
-          possible_type_names = definition.client.schema.possible_types(type).map(&:graphql_name)
+          possible_type_names = definition.client.possible_types(type).map(&:graphql_name)
           possible_types = possible_type_names.map { |concrete_type_name|
             schema_module.get_class(concrete_type_name).define_class(definition, ast_nodes)
           }

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -134,9 +134,8 @@ module GraphQL
             continue_selection = if selected_ast_node.type.nil?
               true
             else
-              schema = definition.client.schema
               type_condition = definition.client.get_type(selected_ast_node.type.name)
-              applicable_types = schema.possible_types(type_condition)
+              applicable_types = definition.client.possible_types(type_condition)
               # continue if this object type is one of the types matching the fragment condition
               applicable_types.include?(type)
             end
@@ -150,10 +149,8 @@ module GraphQL
             fragment_definition = definition.document.definitions.find do |defn|
               defn.is_a?(GraphQL::Language::Nodes::FragmentDefinition) && defn.name == selected_ast_node.name
             end
-
-            schema = definition.client.schema
             type_condition = definition.client.get_type(fragment_definition.type.name)
-            applicable_types = schema.possible_types(type_condition)
+            applicable_types = definition.client.possible_types(type_condition)
             # continue if this object type is one of the types matching the fragment condition
             continue_selection = applicable_types.include?(type)
 

--- a/lib/graphql/client/schema/union_type.rb
+++ b/lib/graphql/client/schema/union_type.rb
@@ -21,7 +21,7 @@ module GraphQL
         end
 
         def define_class(definition, ast_nodes)
-          possible_type_names = definition.client.schema.possible_types(type).map(&:graphql_name)
+          possible_type_names = definition.client.possible_types(type).map(&:graphql_name)
           possible_types = possible_type_names.map { |concrete_type_name|
             schema_module.get_class(concrete_type_name).define_class(definition, ast_nodes)
           }


### PR DESCRIPTION
In GraphQL-Ruby 1.11, `Schema.possible_types` is dynamically calculated and returns a new hash for each call. Like many changes in 1.11, this was done to support Ruby inheritance hierarchies -- since you never know when a class is "finished" (it never is), it recalculates each possibly-inherited value each time it's called. 

In GraphQL-Ruby 1.11, many methods were added to avoid merging (eg, `Schema.get_type(...)` performs a lookup with out creating a new hash, so it's better than `Schema.types[...]`.) 

However, in this case, it seemed _easier_ to: 

- Migrate calls from `client.schema.possible_types(...)` to `client.possible_types(...)`
- Implement `Client#possible_types` to: 
  - use a cached `@possible_types` if the current schema is a class-based on (1.10+)
  - or, delegate to `@schema.possible_types(...)` (<1.10)
  
This preserves the old behavior with minimal changes to the codebase.