### PR TITLE
Deduplicate JSON schemas

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -54,7 +54,7 @@ module GraphQL
         if schema.end_with?(".json") && File.exist?(schema)
           load_schema(File.read(schema))
         elsif schema =~ /\A\s*{/
-          load_schema(JSON.parse(schema))
+          load_schema(JSON.parse(schema, freeze: true))
         end
       else
         if schema.respond_to?(:execute)


### PR DESCRIPTION
JSON schemas tend to have a lot of duplicated strings. On recent `json`, `freeze: true` will deduplicate the strings in the document (see: https://github.com/flori/json/pull/447).

On older ones it should noop.