### PR TITLE
Allow load_schema to accept an IO

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -59,6 +59,8 @@ module GraphQL
       else
         if schema.respond_to?(:execute)
           load_schema(dump_schema(schema))
+        elsif schema.respond_to?(:read)
+          load_schema(schema.read)
         elsif schema.respond_to?(:to_h)
           load_schema(schema.to_h)
         else

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -42,6 +42,13 @@ class TestClientSchema < MiniTest::Test
     assert_equal "AwesomeQuery", schema.query.graphql_name
   end
 
+  def test_load_schema_from_io
+    json = JSON.generate(Schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY))
+    io = StringIO.new(json)
+    schema = GraphQL::Client.load_schema(io)
+    assert_equal "AwesomeQuery", schema.query.graphql_name
+  end
+
   def test_load_schema_ignores_missing_path
     refute GraphQL::Client.load_schema("#{__dir__}/missing-schema.json")
   end


### PR DESCRIPTION
`dump_schema` accepts `IO` objects (`Pathname`, `StringIO`, etc.) but `load_schema` does not.

This results in some surprising behaviour:

```ruby
schema_cache = Pathname('schema-cache.json')

# This works
GraphQL::Client.dump_schema(..., schema_cache)

# This doesn't, until now
GraphQL::Client.load_schema(schema_cache)
```