### PR TITLE
add `to_hash` alias to `to_h` method

### DIFF
--- a/lib/graphql/client/response.rb
+++ b/lib/graphql/client/response.rb
@@ -12,6 +12,7 @@ module GraphQL
       # Returns Hash.
       attr_reader :original_hash
       alias_method :to_h, :original_hash
+      alias_method :to_hash, :original_hash
 
       # Public: Wrapped ObjectType of data returned from the server.
       #

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -192,6 +192,7 @@ module GraphQL
         def to_h
           @data
         end
+        alias :to_hash :to_h
 
         def _definer
           @definer

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -281,6 +281,7 @@ class TestQueryResult < MiniTest::Test
     person = Temp::Person.new(@client.query(Temp::Query).data.me)
     raw_result = {"firstName"=>"Joshua", "lastName"=>"Peek"}
     assert_equal raw_result, person.to_h
+    assert_equal raw_result, person.to_hash
 
     assert_equal "Joshua", person.first_name
     assert_equal "Peek", person.last_name


### PR DESCRIPTION
fixes  #277

Hi 👋 Thanks for the great gem!

0.17.0 breaks as_json/to_json on graphql response because now `ObjectClass` class has `definer` class that has circular references and ActiveSupport(`as_json`) tries to call `instance_values` if `object` doesn't have `to_hash`  methods.

```ruby
response.data.instance_values["definer"].instance_values["klass"].instance_values["null_type"].instance_values["of_klass"].instance_values["null_type"].instance_values["of_klass"]
```

To fix this, I'd like to add `to_hash` method to the relevant classes.
This error itself might not be the concern that this library should care about, but I think it feels more natural if we can get an actual response or data instead of internal variables like `definer` when calling `response.as_json` in the Rails project.

