### PR TITLE
fix: remove graphql version dependency

### DIFF
--- a/graphql-client.gemspec
+++ b/graphql-client.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
 
   s.add_dependency "activesupport", ">= 3.0"
-  s.add_dependency "graphql", "~> 1.10"
+  s.add_dependency "graphql"
 
   s.add_development_dependency "actionpack", ">= 3.2.22"
   s.add_development_dependency "erubi", "~> 1.6"


### PR DESCRIPTION
The graphql gem version was locked to version 1. Per @rmosolgo 's suggestion, I simply removed it from the gemspec.