### PR TITLE
Optimize Schema.set_class

### DIFF
--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -43,7 +43,7 @@ module GraphQL
         def set_class(type_name, klass)
           class_name = normalize_type_name(type_name)
 
-          if constants.include?(class_name.to_sym)
+          if const_defined?(class_name, false)
             raise ArgumentError,
               "Can't define #{class_name} to represent type #{type_name} " \
               "because it's already defined"


### PR DESCRIPTION
`constants.include?` allocate an array every time and does an `O(N)` search.

`const_defined?` saves that allocation and does an `O(1)` lookup.

Additionally it's more correct since it will return `true` for private
constants while `Module#constants` won't include private constants.

For context one of our app spend 10-15% of boot time in there:

```
==================================
  Mode: wall(1000)
  Samples: 17329 (4.89% miss rate)
  GC: 3219 (18.58%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2657  (15.3%)        2657  (15.3%)     (marking)
      2524  (14.6%)        2524  (14.6%)     Module#constants
```

```
==================================
  Mode: cpu(1000)
  Samples: 20400 (4.93% miss rate)
  GC: 4513 (22.12%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3856  (18.9%)        3856  (18.9%)     (marking)
      2569  (12.6%)        2569  (12.6%)     Module#constants
```

<img width="1262" alt="Capture d’écran 2022-06-27 à 12 25 27" src="https://user-images.githubusercontent.com/19192189/175921126-b4bd4cb2-349e-4e54-8e4e-945bc37b89fe.png">
