### PR TITLE
Fix for Ruby 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,13 @@ jobs:
         ruby_version:
           - 2.5.x
           - 2.6.x
+          - 2.7.x
+          - 3.0.x
+          - 3.1.x
         graphql_version:
           - 1.10.14
           - 1.11.1
+          - 1.12.14
         rails_version:
           - "~> 5.2.0"
           - "~> 6.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ graphql_version = ENV["GRAPHQL_VERSION"] == "edge" ? { github: "rmosolgo/graphql
 gem "graphql", graphql_version
 
 group :development, :test do
-  gem "rubocop", "~> 0.82.0"
+  gem "rubocop"
 end

--- a/graphql-client.gemspec
+++ b/graphql-client.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "erubis", "~> 2.7"
   s.add_development_dependency "minitest", "~> 5.9"
   s.add_development_dependency "rake", "~> 11.2"
-  s.add_development_dependency "rubocop-github", "~> 0.10", "<= 0.16.0"
-  s.add_development_dependency "rubocop", "~> 0.55"
+  s.add_development_dependency "rubocop-github", "~> 0.10", "<= 0.18.0"
+  s.add_development_dependency "rubocop"
 
   s.required_ruby_version = ">= 2.1.0"
 

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -132,7 +132,7 @@ module GraphQL
           case selected_ast_node
           when GraphQL::Language::Nodes::InlineFragment
             continue_selection = if selected_ast_node.type.nil?
-              true
+                                   true
             else
               type_condition = definition.client.get_type(selected_ast_node.type.name)
               applicable_types = definition.client.possible_types(type_condition)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -844,4 +844,33 @@ class TestClient < MiniTest::Test
       }
     GRAPHQL
   end
+
+  def test_dynamic_operation_name_query
+    query = @client.parse(<<-'GRAPHQL')
+      query Viewer {
+        viewer {
+          id
+        }
+      }
+    GRAPHQL
+
+    if RUBY_VERSION < "3.0"
+      assert_equal <<-"GRAPHQL".gsub(/^        /, "").chomp, query::Viewer.document.to_query_string
+        query GraphQL__Client__OperationDefinition_#{query::Viewer.object_id} {
+          viewer {
+            id
+          }
+        }
+      GRAPHQL
+    else
+      ptr = query::Viewer.name.gsub(/^.*Module:/, "").gsub(/>.*$/, "")
+      assert_equal <<-"GRAPHQL".gsub(/^        /, "").chomp, query::Viewer.document.to_query_string
+        query Module_#{ptr}__Viewer {
+          viewer {
+            id
+          }
+        }
+      GRAPHQL
+    end
+  end
 end

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -9,11 +9,11 @@ class TestClientSchema < MiniTest::Test
     attr_reader :context
 
     def headers(_)
-     {}
+      {}
     end
 
     def execute(document:, operation_name: nil, variables: {}, context: {})
-     @context = context
+      @context = context
     end
   end
 

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -345,11 +345,8 @@ class TestQueryResult < MiniTest::Test
 
     person = Temp::Person.new(@client.query(Temp::Query).data.me)
 
-    begin
+    assert_raises GraphQL::Client::UnimplementedFieldError, "undefined field `name' on Person type. https://git.io/v1y3m" do
       person.nickname
-      flunk
-    rescue GraphQL::Client::UnimplementedFieldError => e
-      assert_equal "undefined field `nickname' on Person type. https://git.io/v1y3m", e.to_s
     end
   end
 


### PR DESCRIPTION
Summary
- Fx `GraphQL::Client::Definition#definition_name` for Ruby 3.x
- Add test case for `GraphQL::Client::Definition#definition_name`
- Fix test case for Ruby 3.x
- Auto correct by Rubocop
- Add Ruby 2.7, 3.0 & 3.1 version on ci.yml
- Add graphql 1.12.14 version on ci.yml