### PR TITLE
Allow new enum values config

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -90,7 +90,7 @@ module GraphQL
       result
     end
 
-    def initialize(schema:, execute: nil, enforce_collocated_callers: false)
+    def initialize(schema:, execute: nil, enforce_collocated_callers: false, raise_on_unknown_enum_value: true)
       @schema = self.class.load_schema(schema)
       @execute = execute
       @document = GraphQL::Language::Nodes::Document.new(definitions: [])
@@ -100,7 +100,7 @@ module GraphQL
       if schema.is_a?(Class)
         @possible_types = schema.possible_types
       end
-      @types = Schema.generate(@schema)
+      @types = Schema.generate(@schema, raise_on_unknown_enum_value: raise_on_unknown_enum_value)
     end
 
     # A cache of the schema's merged possible types

--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -66,9 +66,10 @@ module GraphQL
         end
       end
 
-      def self.generate(schema)
+      def self.generate(schema, raise_on_unknown_enum_value:)
         mod = Module.new
         mod.extend ClassMethods
+        mod.define_singleton_method(:raise_on_unknown_enum_value) { raise_on_unknown_enum_value }
 
         cache = {}
         schema.types.each do |name, type|


### PR DESCRIPTION
Potential fix for https://github.com/github/graphql-client/issues/288

Adds a configuration for handling unknown enum values returned by the server