### PR TITLE
Add graphql < 2.1 version constraint

### DIFF
--- a/graphql-client.gemspec
+++ b/graphql-client.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
 
   s.add_dependency "activesupport", ">= 3.0"
-  s.add_dependency "graphql"
+  s.add_dependency "graphql", "< 2.1"
 
   s.add_development_dependency "actionpack", ">= 3.2.22"
   s.add_development_dependency "erubi", "~> 1.6"


### PR DESCRIPTION
graphql 2.1.0 removed the Visitor hooks API that graphql-client depends upon (cf. https://github.com/rmosolgo/graphql-ruby/pull/4577).

Ideally, graphql-client should be updated to no longer use that API, but that's probably a tall order. In the meantime, this PR ensures that graphql-client correctly excludes versions of graphql it's not compatible with.

Fixes #310.

@arthurschreiber It would be great if you could release this change as 0.18.1 :)