### PR TITLE
Migrate Visitor usage to support GraphQL-Ruby 2.1

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -425,12 +425,26 @@ module GraphQL
       end.to_h
     end
 
+    class GatherNamesVisitor < GraphQL::Language::Visitor
+      def initialize(node)
+        @names = []
+        super
+      end
+
+      attr_reader :names
+
+      def on_fragment_spread(node, parent)
+        @names << node.name
+        super
+      end
+    end
+
     def find_definition_dependencies(node)
-      names = []
-      visitor = Language::Visitor.new(node)
-      visitor[Language::Nodes::FragmentSpread] << -> (node, parent) { names << node.name }
+      visitor = GatherNamesVisitor.new(node)
       visitor.visit
-      names.uniq
+      names = visitor.names
+      names.uniq!
+      names
     end
 
     def deep_freeze_json_object(obj)

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -2,6 +2,7 @@
 require "active_support/inflector"
 require "active_support/notifications"
 require "graphql"
+require "graphql/client/type_stack"
 require "graphql/client/collocated_enforcement"
 require "graphql/client/definition_variables"
 require "graphql/client/definition"

--- a/lib/graphql/client/document_types.rb
+++ b/lib/graphql/client/document_types.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 require "graphql"
+require "graphql/client/type_stack"
 
 module GraphQL
   class Client
     # Internal: Use schema to detect definition and field types.
     module DocumentTypes
       class AnalyzeTypesVisitor < GraphQL::Language::Visitor
-        include GraphQL::Client::TypeStack
+        prepend GraphQL::Client::TypeStack
         attr_reader :fields
 
         def initialize(*a, **kw)
@@ -30,7 +31,7 @@ module GraphQL
         end
 
         def on_field(node, _parent)
-          @fields[node] = @object_field_definitions.last.type
+          @fields[node] = @field_definitions.last.type
           super
         end
       end

--- a/lib/graphql/client/type_stack.rb
+++ b/lib/graphql/client/type_stack.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+module GraphQL
+  class Client
+    module TypeStack
+      # @return [GraphQL::Schema] the schema whose types are present in this document
+      attr_reader :schema
+
+      # When it enters an object (starting with query or mutation root), it's pushed on this stack.
+      # When it exits, it's popped off.
+      # @return [Array<GraphQL::ObjectType, GraphQL::Union, GraphQL::Interface>]
+      attr_reader :object_types
+
+      # When it enters a field, it's pushed on this stack (useful for nested fields, args).
+      # When it exits, it's popped off.
+      # @return [Array<GraphQL::Field>] fields which have been entered
+      attr_reader :field_definitions
+
+      # Directives are pushed on, then popped off while traversing the tree
+      # @return [Array<GraphQL::Node::Directive>] directives which have been entered
+      attr_reader :directive_definitions
+
+      # @return [Array<GraphQL::Node::Argument>] arguments which have been entered
+      attr_reader :argument_definitions
+
+      # @return [Array<String>] fields which have been entered (by their AST name)
+      attr_reader :path
+
+      # @param schema [GraphQL::Schema] the schema whose types to use when climbing this document
+      # @param visitor [GraphQL::Language::Visitor] a visitor to follow & watch the types
+      def initialize(document, schema:, **rest)
+        @schema = schema
+        @object_types = []
+        @field_definitions = []
+        @directive_definitions = []
+        @argument_definitions = []
+        @path = []
+        super(document, **rest)
+      end
+
+      def on_directive(node, parent)
+        directive_defn = @schema.directives[node.name]
+        @directive_definitions.push(directive_defn)
+        super(node, parent)
+      ensure
+        @directive_definitions.pop
+      end
+
+      def on_field(node, parent)
+        parent_type = @object_types.last
+        parent_type = parent_type.unwrap
+
+        field_definition = @schema.get_field(parent_type, node.name)
+        @field_definitions.push(field_definition)
+        if !field_definition.nil?
+          next_object_type = field_definition.type
+          @object_types.push(next_object_type)
+        else
+          @object_types.push(nil)
+        end
+        @path.push(node.alias || node.name)
+        super(node, parent)
+      ensure
+        @field_definitions.pop
+        @object_types.pop
+        @path.pop
+      end
+
+      def on_argument(node, parent)
+        if @argument_definitions.last
+          arg_type = @argument_definitions.last.type.unwrap
+          if arg_type.kind.input_object?
+            argument_defn = arg_type.arguments[node.name]
+          else
+            argument_defn = nil
+          end
+        elsif @directive_definitions.last
+          argument_defn = @directive_definitions.last.arguments[node.name]
+        elsif @field_definitions.last
+          argument_defn = @field_definitions.last.arguments[node.name]
+        else
+          argument_defn = nil
+        end
+        @argument_definitions.push(argument_defn)
+        @path.push(node.name)
+        super(node, parent)
+      ensure
+        @argument_definitions.pop
+        @path.pop
+      end
+
+      def on_operation_definition(node, parent)
+        # eg, QueryType, MutationType
+        object_type = @schema.root_type_for_operation(node.operation_type)
+        @object_types.push(object_type)
+        @path.push("#{node.operation_type}#{node.name ? " #{node.name}" : ""}")
+        super(node, parent)
+      ensure
+        @object_types.pop
+        @path.pop
+      end
+
+      def on_inline_fragment(node, parent)
+        object_type = if node.type
+          @schema.get_type(node.type.name)
+        else
+          @object_types.last
+        end
+        if !object_type.nil?
+          object_type = object_type.unwrap
+        end
+        @object_types.push(object_type)
+        @path.push("...#{node.type ? " on #{node.type.to_query_string}" : ""}")
+        super(node, parent)
+      ensure
+        @object_types.pop
+        @path.pop
+      end
+
+      def on_fragment_definition(node, parent)
+        object_type = if node.type
+          @schema.get_type(node.type.name)
+        else
+          @object_types.last
+        end
+        if !object_type.nil?
+          object_type = object_type.unwrap
+        end
+        @object_types.push(object_type)
+        @path.push("fragment #{node.name}")
+        super(node, parent)
+      ensure
+        @object_types.pop
+        @path.pop
+      end
+
+      def on_fragment_spread(node, parent)
+        @path.push("... #{node.name}")
+        super(node, parent)
+      ensure
+        @path.pop
+      end
+    end
+  end
+end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -4,9 +4,7 @@ require "graphql/client"
 require "json"
 require "minitest/autorun"
 
-class TestClient < MiniTest::Test
-  GraphQL::DeprecatedDSL.activate if GraphQL::VERSION > "1.8"
-
+class TestClient < Minitest::Test
   module NodeType
     include GraphQL::Schema::Interface
     field :id, ID, null: false
@@ -79,17 +77,13 @@ class TestClient < MiniTest::Test
   class Schema < GraphQL::Schema
     query(QueryType)
     mutation(MutationType)
-    if defined?(GraphQL::Execution::Interpreter)
-      use GraphQL::Execution::Interpreter
-      use GraphQL::Analysis::AST
-    end
   end
 
   module Temp
   end
 
   def setup
-    @client = GraphQL::Client.new(schema: Schema.graphql_definition)
+    @client = GraphQL::Client.new(schema: Schema)
     @client.document_tracking_enabled = true
   end
 

--- a/test/test_client_create_operation.rb
+++ b/test/test_client_create_operation.rb
@@ -3,7 +3,7 @@ require "graphql"
 require "graphql/client"
 require "minitest/autorun"
 
-class TestClientCreateOperation < MiniTest::Test
+class TestClientCreateOperation < Minitest::Test
   class UserType < GraphQL::Schema::Object
     field :id, ID, null: false
   end
@@ -32,11 +32,6 @@ class TestClientCreateOperation < MiniTest::Test
   class Schema < GraphQL::Schema
     query(QueryType)
     mutation(MutationType)
-
-    if defined?(GraphQL::Execution::Interpreter)
-      use GraphQL::Execution::Interpreter
-      use GraphQL::Analysis::AST
-    end
   end
 
   module Temp

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -3,7 +3,7 @@ require "graphql"
 require "graphql/client"
 require "minitest/autorun"
 
-class TestClientErrors < MiniTest::Test
+class TestClientErrors < Minitest::Test
   class FooType < GraphQL::Schema::Object
     field :nullable_error, String, null: true
     def nullable_error
@@ -55,11 +55,6 @@ class TestClientErrors < MiniTest::Test
 
   class Schema < GraphQL::Schema
     query(QueryType)
-
-    if defined?(GraphQL::Execution::Interpreter)
-      use GraphQL::Execution::Interpreter
-      use GraphQL::Analysis::AST
-    end
   end
 
   module Temp

--- a/test/test_client_fetch.rb
+++ b/test/test_client_fetch.rb
@@ -3,7 +3,7 @@ require "graphql"
 require "graphql/client"
 require "minitest/autorun"
 
-class TestClientFetch < MiniTest::Test
+class TestClientFetch < Minitest::Test
   class QueryType < GraphQL::Schema::Object
     field :version, Integer, null: false
     def version

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -4,7 +4,7 @@ require "graphql/client"
 require "json"
 require "minitest/autorun"
 
-class TestClientSchema < MiniTest::Test
+class TestClientSchema < Minitest::Test
   FakeConn = Class.new do
     attr_reader :context
 

--- a/test/test_client_validation.rb
+++ b/test/test_client_validation.rb
@@ -3,7 +3,7 @@ require "graphql"
 require "graphql/client"
 require "minitest/autorun"
 
-class TestClientValidation < MiniTest::Test
+class TestClientValidation < Minitest::Test
   class UserType < GraphQL::Schema::Object
     field :name, String, null: false
   end

--- a/test/test_collocated_enforcement.rb
+++ b/test/test_collocated_enforcement.rb
@@ -3,7 +3,7 @@ require "graphql/client/collocated_enforcement"
 require "minitest/autorun"
 require_relative "foo_helper"
 
-class TestCollocatedEnforcement < MiniTest::Test
+class TestCollocatedEnforcement < Minitest::Test
   include FooHelper
 
   class Person

--- a/test/test_definition_variables.rb
+++ b/test/test_definition_variables.rb
@@ -4,7 +4,7 @@ require "graphql/client"
 require "graphql/client/definition_variables"
 require "minitest/autorun"
 
-class TestDefinitionVariables < MiniTest::Test
+class TestDefinitionVariables < Minitest::Test
   class QueryType < GraphQL::Schema::Object
     field :version, Integer, null: false
     field :user, String, null: false do

--- a/test/test_erb.rb
+++ b/test/test_erb.rb
@@ -8,7 +8,7 @@ require "graphql/client/erubis_enhancer"
 require "graphql/client/view_module"
 require "minitest/autorun"
 
-class TestERB < MiniTest::Test
+class TestERB < Minitest::Test
   class ErubiEngine < Erubi::Engine
     include GraphQL::Client::ErubiEnhancer
   end

--- a/test/test_hash_with_indifferent_access.rb
+++ b/test/test_hash_with_indifferent_access.rb
@@ -2,7 +2,7 @@
 require "graphql/client/hash_with_indifferent_access"
 require "minitest/autorun"
 
-class TestHashWithIndifferentAccess < MiniTest::Test
+class TestHashWithIndifferentAccess < Minitest::Test
   def test_string_access
     hash = GraphQL::Client::HashWithIndifferentAccess.new("foo" => 42)
     assert_equal 42, hash["foo"]

--- a/test/test_http.rb
+++ b/test/test_http.rb
@@ -3,7 +3,7 @@ require "graphql"
 require "graphql/client/http"
 require "minitest/autorun"
 
-class TestHTTP < MiniTest::Test
+class TestHTTP < Minitest::Test
   SWAPI = GraphQL::Client::HTTP.new("https://mpjk0plp9.lp.gql.zone/graphql") do
     def headers(_context)
       { "User-Agent" => "GraphQL/1.0" }

--- a/test/test_object_typename.rb
+++ b/test/test_object_typename.rb
@@ -4,7 +4,7 @@ require "graphql/client"
 require "minitest/autorun"
 require "ostruct"
 
-class TestObjectTypename < MiniTest::Test
+class TestObjectTypename < Minitest::Test
   class PersonType < GraphQL::Schema::Object
     field :id, Integer, null: true
     def id; 42; end

--- a/test/test_operation_slice.rb
+++ b/test/test_operation_slice.rb
@@ -2,7 +2,7 @@
 require "graphql"
 require "minitest/autorun"
 
-class TestDefinitionSlice < MiniTest::Test
+class TestDefinitionSlice < Minitest::Test
   def test_slice_simple_query_operation
     document = GraphQL.parse(<<-'GRAPHQL')
       query FooQuery {

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -6,7 +6,7 @@ require "time" # required for Time#iso8601
 require "ostruct"
 require_relative "foo_helper"
 
-class TestQueryResult < MiniTest::Test
+class TestQueryResult < Minitest::Test
   class DateTimeType < GraphQL::Schema::Scalar
     def self.coerce_input(value, ctx)
       Time.iso8601(value)

--- a/test/test_query_typename.rb
+++ b/test/test_query_typename.rb
@@ -3,7 +3,7 @@ require "graphql"
 require "graphql/client/query_typename"
 require "minitest/autorun"
 
-class TestQueryTypename < MiniTest::Test
+class TestQueryTypename < Minitest::Test
   class PersonType < GraphQL::Schema::Object
     field :id, Integer, null: true
     def id; 42; end

--- a/test/test_rubocop_heredoc.rb
+++ b/test/test_rubocop_heredoc.rb
@@ -2,7 +2,7 @@
 require "rubocop/cop/graphql/heredoc"
 require "minitest/autorun"
 
-class TestRubocopHeredoc < MiniTest::Test
+class TestRubocopHeredoc < Minitest::Test
   def setup
     config = RuboCop::Config.new
     @cop = RuboCop::Cop::GraphQL::Heredoc.new(config)

--- a/test/test_rubocop_overfetch.rb
+++ b/test/test_rubocop_overfetch.rb
@@ -3,7 +3,7 @@ require "graphql/client/erb"
 require "rubocop/cop/graphql/overfetch"
 require "minitest/autorun"
 
-class TestRubocopOverfetch < MiniTest::Test
+class TestRubocopOverfetch < Minitest::Test
   Root = File.expand_path("..", __FILE__)
 
   def setup

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -4,7 +4,7 @@ require "graphql/client/schema"
 require "minitest/autorun"
 require "time"
 
-class TestSchemaType < MiniTest::Test
+class TestSchemaType < Minitest::Test
   GraphQL::DeprecatedDSL.activate if GraphQL::VERSION > "1.8"
 
   DateTime = GraphQL::ScalarType.define do

--- a/test/test_view_module.rb
+++ b/test/test_view_module.rb
@@ -4,7 +4,7 @@ require "graphql/client"
 require "graphql/client/view_module"
 require "minitest/autorun"
 
-class TestViewModule < MiniTest::Test
+class TestViewModule < Minitest::Test
   Root = File.expand_path("..", __FILE__)
 
   class UserType < GraphQL::Schema::Object


### PR DESCRIPTION
Fixes https://github.com/github/graphql-client/issues/310


This will be tough to confirm ... there's a lot of `.define` in here, which doesn't run on GraphQL-Ruby 2.0+. CI only runs 1.10 and 1.11, so it might not pass.


My goal is to find all `Visitor.new` references and replace them with custom visitor classes, moving the `[node_class] <<` hooks to methods. 


Tests that pass locally:
- [x] `test/test_definition_variables.rb` 
- [x] `test/test_client.rb` 
- [x] `test/test_query_typename.rb`
- [x] `test/test_rubocop_overfetch.rb`